### PR TITLE
fix: gitignore node_modules at any depth + Expo ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
-# dependencies
-/node_modules
+# dependencies — all depths (web, mobile, any future packages)
+node_modules/
 /.pnp
 .pnp.js
 
@@ -28,3 +28,18 @@ yarn-error.log*
 
 # Vercel
 .vercel/
+
+# Expo / React Native
+.expo/
+mobile/.expo/
+mobile/dist/
+mobile/android/
+mobile/ios/
+*.jks
+*.p8
+*.p12
+*.key
+*.mobileprovision
+*.orig.*
+google-services.json
+GoogleService-Info.plist


### PR DESCRIPTION
## What this PR does

Fixes `.gitignore` so `mobile/node_modules` (and any future nested `node_modules`) stops being tracked by Git.

## Change

| Before | After |
|---|---|
| `/node_modules` (root only) | `node_modules/` (any depth) |

## Also added Expo-specific ignores
- `.expo/` and `mobile/.expo/`
- `mobile/android/` and `mobile/ios/` (generated by EAS build, not hand-edited)
- `*.jks`, `*.p12`, `*.key`, `*.mobileprovision` — signing secrets
- `google-services.json` and `GoogleService-Info.plist` — Firebase config secrets

## After merging
If `mobile/node_modules` is still showing in VS Code's Git panel, run once:
```bash
git rm -r --cached mobile/node_modules
```
This removes it from Git's index without deleting the files.