### PR TITLE
fix: upgrade to Expo SDK 54 to match Expo Go

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -12,19 +12,19 @@
     "submit:ios": "eas submit --platform ios"
   },
   "dependencies": {
-    "expo": "~51.0.0",
-    "expo-router": "~3.5.0",
-    "expo-status-bar": "~1.12.1",
-    "react": "18.2.0",
-    "react-native": "0.74.5",
-    "@react-native-firebase/app": "^20.0.0",
-    "@react-native-firebase/auth": "^20.0.0",
-    "@react-native-firebase/firestore": "^20.0.0",
+    "expo": "~54.0.0",
+    "expo-router": "~4.0.0",
+    "expo-status-bar": "~2.0.0",
+    "react": "18.3.1",
+    "react-native": "0.76.5",
+    "@react-native-firebase/app": "^21.0.0",
+    "@react-native-firebase/auth": "^21.0.0",
+    "@react-native-firebase/firestore": "^21.0.0",
     "@react-navigation/native": "^6.1.0",
-    "react-native-safe-area-context": "4.10.5",
-    "react-native-screens": "3.31.1"
+    "react-native-safe-area-context": "~4.12.0",
+    "react-native-screens": "~4.4.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.24.0"
+    "@babel/core": "^7.25.0"
   }
 }


### PR DESCRIPTION
## What this PR does

Upgrades the mobile app from **Expo SDK 51 → SDK 54** to match the current Expo Go version (SDK 54) installed on iOS/Android devices.

## Changes

| Package | Was | Now |
|---|---|---|
| `expo` | ~51.0.0 | ~54.0.0 |
| `expo-router` | ~3.5.0 | ~4.0.0 |
| `expo-status-bar` | ~1.12.1 | ~2.0.0 |
| `react` | 18.2.0 | 18.3.1 |
| `react-native` | 0.74.5 | 0.76.5 |
| `@react-native-firebase/*` | ^20.0.0 | ^21.0.0 |
| `react-native-safe-area-context` | 4.10.5 | ~4.12.0 |
| `react-native-screens` | 3.31.1 | ~4.4.0 |

## After merging

Run in the mobile folder:
```powershell
cd mobile
rm -r node_modules
npm install
npm start -- --tunnel
```

Scan the QR with Expo Go — should work without the SDK incompatibility error.