### PR TITLE
fix: remove asset refs + add missing mobile deps

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -4,23 +4,13 @@
     "slug": "rewardsfindr",
     "version": "1.0.0",
     "orientation": "portrait",
-    "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
-    "splash": {
-      "image": "./assets/splash.png",
-      "resizeMode": "contain",
-      "backgroundColor": "#4f46e5"
-    },
     "ios": {
       "supportsTablet": false,
       "bundleIdentifier": "com.rewardsfindr.app",
       "buildNumber": "1"
     },
     "android": {
-      "adaptiveIcon": {
-        "foregroundImage": "./assets/adaptive-icon.png",
-        "backgroundColor": "#4f46e5"
-      },
       "package": "com.rewardsfindr.app",
       "versionCode": 1
     },
@@ -32,6 +22,9 @@
       "eas": {
         "projectId": "REPLACE_WITH_EAS_PROJECT_ID"
       }
+    },
+    "web": {
+      "bundler": "metro"
     }
   }
 }

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -17,6 +17,7 @@
     "expo-status-bar": "~2.0.0",
     "react": "18.3.1",
     "react-native": "0.76.5",
+    "react-native-web": "~0.19.13",
     "@react-native-firebase/app": "^21.0.0",
     "@react-native-firebase/auth": "^21.0.0",
     "@react-native-firebase/firestore": "^21.0.0",
@@ -25,6 +26,7 @@
     "react-native-screens": "~4.4.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.25.0"
+    "@babel/core": "^7.25.0",
+    "babel-preset-expo": "~12.0.0"
   }
 }


### PR DESCRIPTION
## What this PR does

Fixes two bundling errors:
1. **Missing assets** — removed `icon.png` / `splash.png` / `adaptive-icon.png` references from `app.json` until real assets are added
2. **Missing dependencies** — added `react-native-web` and `babel-preset-expo` to `package.json`

## Changes

### `mobile/app.json`
- Removed `icon`, `splash`, and `adaptiveIcon` fields (will re-add when assets exist)
- Added `"web": { "bundler": "metro" }` to disable web warnings

### `mobile/package.json`
- Added `react-native-web` ~0.19.13 (required by expo-router even if not targeting web)
- Moved `babel-preset-expo` to devDependencies (was missing)

## After merging

```bash
cd /d/RewardsFindr/rewardsfindr/mobile
rm -rf node_modules package-lock.json
npm install
npm start -- --tunnel
```

Should bundle cleanly now.