### PR TITLE
fix: remove Firebase deps so app runs in Expo Go

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -14,10 +14,6 @@
       "package": "com.rewardsfindr.app",
       "versionCode": 1
     },
-    "plugins": [
-      "@react-native-firebase/app",
-      "@react-native-firebase/auth"
-    ],
     "extra": {
       "eas": {
         "projectId": "REPLACE_WITH_EAS_PROJECT_ID"

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -18,9 +18,6 @@
     "react": "18.3.1",
     "react-native": "0.76.5",
     "react-native-web": "~0.19.13",
-    "@react-native-firebase/app": "^21.0.0",
-    "@react-native-firebase/auth": "^21.0.0",
-    "@react-native-firebase/firestore": "^21.0.0",
     "@react-navigation/native": "^6.1.0",
     "react-native-safe-area-context": "~4.12.0",
     "react-native-screens": "~4.4.0"


### PR DESCRIPTION
## What this PR does

Removes Firebase dependencies temporarily so the app can run in **Expo Go** without needing a custom development build.

## Why

Firebase native modules (`@react-native-firebase/*`) require a **development build** — they can't run in Expo Go. Since Firebase auth isn't wired to the UI yet anyway, and your Google account needs to be independent before OAuth works, removing them now lets you test the full app flow (search + results) today.

## Changes

### `mobile/package.json`
Removed:
- `@react-native-firebase/app`
- `@react-native-firebase/auth`
- `@react-native-firebase/firestore`

### `mobile/app.json`
Removed `plugins` array (Firebase plugins no longer needed)

## After merging

```bash
cd /d/RewardsFindr/rewardsfindr/mobile
rm -rf node_modules package-lock.json
npm install
npm start -- --tunnel
```

Scan the QR with Expo Go — app should load fully now.

## When to add Firebase back

1. Google account becomes independent (next couple days)
2. Do a development build: `npx eas build --profile development --platform ios`
3. Install the custom build on your phone
4. Re-add Firebase deps + wire auth to the UI

For now this unblocks you from testing the core search flow.