### PR TITLE
fix: remove Capital One content script reference

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -40,14 +40,6 @@
       ],
       "js": ["content/amex.js"],
       "run_at": "document_idle"
-    },
-    {
-      "matches": [
-        "https://www.capitalone.com/card-benefits/offers*",
-        "https://www.capitalone.com/*offers*"
-      ],
-      "js": ["content/capitalOne.js"],
-      "run_at": "document_idle"
     }
   ],
 
@@ -59,8 +51,7 @@
 
   "host_permissions": [
     "https://*.chase.com/*",
-    "https://*.americanexpress.com/*",
-    "https://*.capitalone.com/*"
+    "https://*.americanexpress.com/*"
   ],
 
   "oauth2": {


### PR DESCRIPTION
## Problem
Extension fails to load with error:
```
Could not load javascript 'content/capitalOne.js' for script.
```

## Solution
Removed the Capital One content script reference from `manifest.json` since the file doesn't exist yet.

Also removed Capital One from `host_permissions` to keep the manifest clean.

## Testing
- Load extension in Chrome - should load without errors
- Chase and Amex scrapers still work

## Future
We can add Capital One support back when we create `content/capitalOne.js`