### PR TITLE
fix: load dotenv before Firebase config imports

### DIFF
--- a/api/config/firebase.js
+++ b/api/config/firebase.js
@@ -2,7 +2,11 @@
 // FIREBASE ADMIN SDK INITIALIZATION
 // Single source of truth for server-side Firebase
 // ─────────────────────────────────────────────
+import dotenv from 'dotenv';
 import admin from 'firebase-admin';
+
+// Load .env BEFORE accessing process.env
+dotenv.config();
 
 // Initialize Firebase Admin with service account credentials from env
 const serviceAccount = {
@@ -12,6 +16,10 @@ const serviceAccount = {
 };
 
 if (!serviceAccount.projectId || !serviceAccount.clientEmail || !serviceAccount.privateKey) {
+  console.error('Missing Firebase credentials. Check your .env file.');
+  console.error('PROJECT_ID:', serviceAccount.projectId ? '✓' : '✗');
+  console.error('CLIENT_EMAIL:', serviceAccount.clientEmail ? '✓' : '✗');
+  console.error('PRIVATE_KEY:', serviceAccount.privateKey ? '✓' : '✗');
   throw new Error('Missing Firebase Admin SDK credentials in environment variables');
 }
 


### PR DESCRIPTION
## Issue
The API was failing to start because `firebase.js` was trying to access `process.env` variables before `dotenv.config()` was called in `index.js`.

## Fix
Moved `dotenv.config()` into `firebase.js` itself so environment variables are loaded before the Firebase Admin SDK tries to initialize.

Also added debug logging to show which credentials are found/missing if initialization fails.

## Testing
After merging, run:
```bash
cd api
npm run dev
```

Should see:
```
✅ Firebase Admin initialized for project: rewardsfindr-dev
🚀 RewardsFindr API running on http://localhost:3001
```