### PR TITLE
fix: downgrade to Expo SDK 52 to resolve TurboModule runtime errors

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -12,7 +12,7 @@
     "submit:ios": "eas submit --platform ios"
   },
   "dependencies": {
-    "expo": "~54.0.0",
+    "expo": "~52.0.0",
     "expo-router": "~4.0.0",
     "expo-status-bar": "~2.0.0",
     "react": "18.3.1",
@@ -21,8 +21,7 @@
     "@react-navigation/native": "^6.1.0",
     "react-native-safe-area-context": "~4.12.0",
     "react-native-screens": "~4.4.0",
-    "firebase": "^10.13.0",
-    "expo-constants": "~17.0.0"
+    "firebase": "^10.13.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.0",


### PR DESCRIPTION
## Problem
Expo SDK 54 is causing `TurboModuleRegistry` and `PlatformConstants` runtime errors when the app starts in Expo Go.

## Solution
Downgrade to **Expo SDK 52** (more stable, better compatibility with React Native 0.76.5).

Also removed `expo-constants` dependency as it's not needed in our current setup.

## After Merging
```bash
cd mobile
git pull origin main
rm -rf node_modules package-lock.json
npm install
npx expo start --clear
```