### PR TITLE
fix: make Firebase credentials configurable in extension

### DIFF
--- a/extension/.gitignore
+++ b/extension/.gitignore
@@ -1,0 +1,9 @@
+# Config with secrets
+config.js
+
+# Node modules if we add build tools later
+node_modules/
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/extension/README.md
+++ b/extension/README.md
@@ -1,0 +1,42 @@
+# RewardsFindr Chrome Extension
+
+Automatically syncs bank credit card offers to RewardsFindr.
+
+## Setup
+
+1. **Create config file:**
+   ```bash
+   cp config.example.js config.js
+   ```
+
+2. **Fill in your Firebase credentials in `config.js`:**
+   - Get Firebase API key from Firebase Console → Project Settings → Web app
+   - Update `FIREBASE_API_KEY` and `FIREBASE_AUTH_DOMAIN`
+   - Set `API_URL` to your backend (default: `http://localhost:3001`)
+
+3. **Update `manifest.json` with your OAuth2 client ID:**
+   - Go to Google Cloud Console → APIs & Credentials
+   - Create OAuth 2.0 Client ID for Chrome Extension
+   - Extension ID: Get from `chrome://extensions`
+   - Copy client ID to `manifest.json` under `oauth2.client_id`
+
+4. **Load extension in Chrome:**
+   - Go to `chrome://extensions`
+   - Enable "Developer mode"
+   - Click "Load unpacked"
+   - Select this `extension/` folder
+
+## Usage
+
+1. Click extension icon
+2. Sign in with Google
+3. Visit your bank's offers page (Chase or Amex)
+4. Extension auto-scrapes and syncs offers
+5. Check popup to see synced cards
+
+## Supported Banks
+
+- ✅ Chase
+- ✅ American Express
+- ⏳ Capital One (coming soon)
+- ⏳ Citi (coming soon)

--- a/extension/background.js
+++ b/extension/background.js
@@ -7,7 +7,9 @@
 //   3. Updates extension badge to show sync status
 // ─────────────────────────────────────────────
 
-const API_URL = 'http://localhost:3001'; // TODO: Change to production URL
+import { CONFIG } from './config.js';
+
+const API_URL = CONFIG.API_URL;
 
 // ─────────────────────────────────────────────
 // BADGE HELPERS

--- a/extension/config.example.js
+++ b/extension/config.example.js
@@ -1,0 +1,13 @@
+// ─────────────────────────────────────────────
+// EXTENSION CONFIG
+// Copy this to config.js and fill in your values
+// ─────────────────────────────────────────────
+
+export const CONFIG = {
+  // Get from Firebase Console -> Project Settings -> Web app
+  FIREBASE_API_KEY: 'your_firebase_api_key_here',
+  FIREBASE_AUTH_DOMAIN: 'your-project.firebaseapp.com',
+  
+  // Your API backend URL
+  API_URL: 'http://localhost:3001',
+};

--- a/extension/lib/auth.js
+++ b/extension/lib/auth.js
@@ -4,8 +4,7 @@
 // Can't use Firebase SDK in extensions due to CSP
 // ─────────────────────────────────────────────
 
-const FIREBASE_API_KEY = 'AIzaSyBVe-sMZEm_vGZtMc5hBu6xJZJLtQZqZqM';
-const FIREBASE_AUTH_DOMAIN = 'rewardsfindr-dev.firebaseapp.com';
+import { CONFIG } from '../config.js';
 
 /**
  * Sign in with Google using Chrome Identity API
@@ -28,13 +27,13 @@ export async function signInWithGoogle() {
       try {
         // Exchange Google token for Firebase token
         const response = await fetch(
-          `https://identitytoolkit.googleapis.com/v1/accounts:signInWithIdp?key=${FIREBASE_API_KEY}`,
+          `https://identitytoolkit.googleapis.com/v1/accounts:signInWithIdp?key=${CONFIG.FIREBASE_API_KEY}`,
           {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
               postBody: `id_token=${token}&providerId=google.com`,
-              requestUri: `https://${FIREBASE_AUTH_DOMAIN}`,
+              requestUri: `https://${CONFIG.FIREBASE_AUTH_DOMAIN}`,
               returnIdpCredential: true,
               returnSecureToken: true,
             }),


### PR DESCRIPTION
## Problem
Firebase API key was hardcoded in `lib/auth.js`, causing "API key not valid" errors.

## Solution
Created a config system for the extension:

### What's New
- **`config.example.js`** - Template with placeholder values
- **`config.js`** - Gitignored file where you put real credentials
- **`.gitignore`** - Excludes `config.js` from git
- **README.md** - Setup instructions

### Files Updated
- `lib/auth.js` - Now imports from `config.js`
- `background.js` - Now imports API_URL from `config.js`

## Setup Instructions

1. **Copy config template:**
   ```bash
   cd extension
   cp config.example.js config.js
   ```

2. **Edit `config.js` with your real values:**
   ```javascript
   export const CONFIG = {
     FIREBASE_API_KEY: 'YOUR_ACTUAL_KEY',
     FIREBASE_AUTH_DOMAIN: 'rewardsfindr-dev.firebaseapp.com',
     API_URL: 'http://localhost:3001',
   };
   ```

3. **Get your Firebase API key:**
   - Firebase Console → Project Settings → General → Your apps → Web app
   - Or check your `mobile/.env.development` file

4. **Update manifest.json oauth2.client_id:**
   - Use the client ID you created earlier for extension ID: `jmfghagcdebknnngjgakibgeeinlhjfp`

5. **Reload extension** in Chrome

## Next Steps
After merging, you need to locally create `extension/config.js` with your real credentials.