### PR TITLE
fix: broken firebase import, add cardName/bank to sync, query Firestore in search

### DIFF
--- a/api/routes/offers.js
+++ b/api/routes/offers.js
@@ -3,20 +3,21 @@
 // Handle syncing offers from Chrome extension
 // ─────────────────────────────────────────────
 import express from 'express';
-import admin from '../firebase.js';
+import { db, auth } from '../config/firebase.js';
+import { FieldValue } from 'firebase-admin/firestore';
 import { generateOfferId, normalizeMerchant } from '../../shared/offerUtils.js';
 
 const router = express.Router();
-const db = admin.firestore();
 
 /**
  * POST /api/offers/sync
  * Sync offers from Chrome extension to Firestore
  * Requires Firebase authentication
+ * Body: { offers: [], bank: string, cardName: string }
  */
 router.post('/sync', async (req, res) => {
   try {
-    // Get Firebase ID token from Authorization header
+    // Verify auth token
     const authHeader = req.headers.authorization;
     if (!authHeader?.startsWith('Bearer ')) {
       return res.status(401).json({ error: 'Missing or invalid authorization header' });
@@ -24,42 +25,41 @@ router.post('/sync', async (req, res) => {
 
     const idToken = authHeader.split('Bearer ')[1];
 
-    // Verify Firebase token
     let decodedToken;
     try {
-      decodedToken = await admin.auth().verifyIdToken(idToken);
+      decodedToken = await auth.verifyIdToken(idToken);
     } catch (error) {
       console.error('Token verification failed:', error);
       return res.status(401).json({ error: 'Invalid authentication token' });
     }
 
     const userId = decodedToken.uid;
-    const { offers } = req.body;
+    const { offers, bank, cardName } = req.body;
 
     if (!offers || !Array.isArray(offers)) {
       return res.status(400).json({ error: 'Invalid offers data' });
     }
 
-    console.log(`🔄 Syncing ${offers.length} offers for user ${userId}`);
+    if (!bank || !cardName) {
+      return res.status(400).json({ error: 'bank and cardName are required' });
+    }
 
-    // Process offers and write to Firestore
+    console.log(`🔄 Syncing ${offers.length} offers for user ${userId} (${bank} - ${cardName})`);
+
     const batch = db.batch();
     let syncedCount = 0;
     let skippedCount = 0;
 
     for (const offer of offers) {
       try {
-        // Generate deterministic offer ID
         const offerId = generateOfferId(
           offer.merchantName,
           offer.cashbackAmount,
-          offer.expiryDate || new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString() // Default 90 days if no expiry
+          offer.expiryDate || new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString()
         );
 
-        // Normalize merchant name for search matching
         const normalizedMerchant = normalizeMerchant(offer.merchantName);
 
-        // Prepare offer document
         const offerDoc = {
           offerId,
           userId,
@@ -72,11 +72,11 @@ router.post('/sync', async (req, res) => {
           category: offer.category || 'other',
           expiryDate: offer.expiryDate || null,
           isActivated: offer.isActivated || false,
-          bank: 'chase', // TODO: Get from request
-          syncedAt: admin.firestore.FieldValue.serverTimestamp(),
+          bank,
+          cardName,
+          syncedAt: FieldValue.serverTimestamp(),
         };
 
-        // Use offerId as document ID to prevent duplicates
         const offerRef = db.collection('offers').doc(offerId);
         batch.set(offerRef, offerDoc, { merge: true });
         syncedCount++;
@@ -87,7 +87,6 @@ router.post('/sync', async (req, res) => {
       }
     }
 
-    // Commit batch write
     await batch.commit();
 
     console.log(`✅ Sync complete: ${syncedCount} synced, ${skippedCount} skipped`);

--- a/api/routes/search.js
+++ b/api/routes/search.js
@@ -1,57 +1,110 @@
 // ─────────────────────────────────────────────
 // SEARCH ROUTES
 // Handle store search and card recommendations
+// Returns:
+//   - personalizedOffers: user's own synced offers (requires auth)
+//   - cards: general card recommendations for everyone
 // ─────────────────────────────────────────────
 import express from 'express';
+import { db, auth } from '../config/firebase.js';
 import { CARDS } from '../../shared/constants.js';
-import { buildStoreLookup, findBestStoreMatch, buildResultsForCategory } from '../../shared/offerUtils.js';
+import {
+  buildStoreLookup,
+  findBestStoreMatch,
+  buildResultsForCategory,
+  normalizeMerchant,
+} from '../../shared/offerUtils.js';
 
 const router = express.Router();
 const STORE_LOOKUP = buildStoreLookup();
 
 /**
  * GET /api/search?q=storename
- * Search for best credit card rewards for a store
+ * Optional: Authorization: Bearer <firebaseIdToken>
+ *
+ * Always returns general card recommendations.
+ * If authenticated, also returns user's personalized synced offers.
  */
-router.get('/', (req, res) => {
+router.get('/', async (req, res) => {
   try {
     const query = req.query.q;
 
     if (!query || !query.trim()) {
-      return res.status(400).json({ 
+      return res.status(400).json({
         error: 'Search query is required',
-        example: '/api/search?q=amazon'
+        example: '/api/search?q=amazon',
       });
     }
 
     console.log(`🔍 Search query: "${query}"`);
 
-    // Find best store match
+    // ── 1. Match store from our known store list ──────────────────────
     const match = findBestStoreMatch(query, STORE_LOOKUP);
 
-    if (!match) {
+    // ── 2. General card results (available to everyone) ───────────────
+    const generalCards = match
+      ? buildResultsForCategory(match.category, CARDS).map(card => ({
+          ...card,
+          source: 'general',
+        }))
+      : [];
+
+    // ── 3. Personalized offers from Firestore (auth optional) ─────────
+    let personalizedOffers = [];
+    const authHeader = req.headers.authorization;
+
+    if (authHeader?.startsWith('Bearer ')) {
+      try {
+        const idToken = authHeader.split('Bearer ')[1];
+        const decodedToken = await auth.verifyIdToken(idToken);
+        const userId = decodedToken.uid;
+
+        // Normalize query for exact Firestore field match
+        const normalizedQuery = normalizeMerchant(query);
+
+        const offersSnapshot = await db.collection('offers')
+          .where('userId', '==', userId)
+          .where('normalizedMerchant', '==', normalizedQuery)
+          .get();
+
+        if (!offersSnapshot.empty) {
+          personalizedOffers = offersSnapshot.docs.map(doc => ({
+            ...doc.data(),
+            source: 'synced',
+          }));
+          console.log(`✅ Found ${personalizedOffers.length} personalized offers for "${query}" (user: ${userId})`);
+        } else {
+          console.log(`ℹ️  No personalized offers found for "${query}" (user: ${userId})`);
+        }
+      } catch (tokenError) {
+        // Bad token — gracefully skip personalized results, don't fail
+        console.warn('[Search] Token verification failed, returning general results only:', tokenError.message);
+      }
+    }
+
+    // ── 4. No results at all ──────────────────────────────────────────
+    if (!match && personalizedOffers.length === 0) {
       console.log(`❌ No match found for "${query}"`);
       return res.json({
         store: null,
         category: null,
         quality: null,
+        personalizedOffers: [],
         cards: [],
-        message: `No matches found for "${query}"`
+        message: `No matches found for "${query}"`,
+        query,
       });
     }
 
-    console.log(`✅ Match found: ${match.displayName} (${match.category})`);
-
-    // Build card results for the matched category
-    const cards = buildResultsForCategory(match.category, CARDS);
-
     res.json({
-      store: match.displayName,
-      category: match.category,
-      quality: match.quality,
-      cards: cards,
-      query: query
+      store: match?.displayName || query,
+      category: match?.category || null,
+      quality: match?.quality || null,
+      personalizedOffers,
+      cards: generalCards,
+      query,
     });
+
   } catch (error) {
     console.error('Search error:', error);
     res.status(500).json({ error: 'Search failed' });

--- a/extension/background.js
+++ b/extension/background.js
@@ -39,16 +39,16 @@ const getAuthToken = async () => {
 
 // ─────────────────────────────────────────────
 // SYNC TO API
-// Sends offers to backend API with authentication
+// Sends offers + bank + cardName to backend API
 // ─────────────────────────────────────────────
-const syncToAPI = async (offers, token) => {
+const syncToAPI = async (offers, bank, cardName, token) => {
   const response = await fetch(`${API_URL}/api/offers/sync`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       'Authorization': `Bearer ${token}`,
     },
-    body: JSON.stringify({ offers }),
+    body: JSON.stringify({ offers, bank, cardName }),
   });
 
   if (!response.ok) {
@@ -62,7 +62,6 @@ const syncToAPI = async (offers, token) => {
 // ─────────────────────────────────────────────
 // PROCESS OFFERS
 // Called when a content script sends parsed offers
-// Now syncs to API instead of just local storage
 // ─────────────────────────────────────────────
 const processOffers = async (bank, cardName, rawOffers) => {
   if (!rawOffers?.length) {
@@ -75,7 +74,6 @@ const processOffers = async (bank, cardName, rawOffers) => {
 
   console.log(`[Background] Processing ${rawOffers.length} offers from ${bank} (${cardName})`);
 
-  // Check if user is logged in
   const token = await getAuthToken();
   if (!token) {
     console.warn('[Background] User not logged in — cannot sync to API');
@@ -84,10 +82,9 @@ const processOffers = async (bank, cardName, rawOffers) => {
   }
 
   try {
-    // Sync to API
-    const result = await syncToAPI(rawOffers, token);
+    const result = await syncToAPI(rawOffers, bank, cardName, token);
     console.log(`[Background] ✅ API sync successful:`, result);
-    
+
     // Also store in local storage as backup
     await chrome.storage.local.set({
       [`offers_${bank}_${cardName}`]: {
@@ -117,7 +114,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   // Content script finished parsing offers
   if (message.type === 'OFFERS_PARSED') {
     const { bank, cardName, offers } = message.payload;
-    console.log(`[Background] Received ${offers?.length} offers from ${bank}`);
+    console.log(`[Background] Received ${offers?.length} offers from ${bank} (${cardName})`);
 
     processOffers(bank, cardName, offers)
       .then(result => sendResponse(result))


### PR DESCRIPTION
## Problem
Three bugs were preventing the extension → Firestore data pipeline from working:

### Bug 1 — Wrong Firebase import path (`offers.js`)
```js
// ❌ Before (file doesn't exist)
import admin from '../firebase.js';

// ✅ After
import { db, auth } from '../config/firebase.js';
import { FieldValue } from 'firebase-admin/firestore';
```
This was causing the entire sync endpoint to crash on startup. **Nothing was ever saved to Firestore.**

### Bug 2 — `bank` and `cardName` not sent to API (`background.js`)
```js
// ❌ Before
body: JSON.stringify({ offers })

// ✅ After
body: JSON.stringify({ offers, bank, cardName })
```
`background.js` received `bank` and `cardName` from the content script but never forwarded them in the API request body.

### Bug 3 — Search never queried Firestore (`search.js`)
The search endpoint was returning hardcoded `CARDS` data only — it never touched Firestore at all.

---

## Changes

### `api/routes/offers.js`
- Fixed import path to `../config/firebase.js`
- Now reads `bank` and `cardName` from request body (required fields)
- Saves both fields on every offer document in Firestore
- Uses named `{ db, auth }` exports + `FieldValue` from `firebase-admin/firestore`

### `extension/background.js`
- `syncToAPI()` now accepts and sends `bank` and `cardName` in the request body

### `api/routes/search.js`
- Auth is now **optional** — works with or without a token
- If authenticated → queries Firestore for user's personalized offers matching `normalizedMerchant`
- Always → returns general card recommendations from `shared/constants.js`
- Response shape:
```json
{
  "store": "Amazon",
  "category": "shopping",
  "quality": "exact",
  "personalizedOffers": [ /* from Firestore, source: 'synced' */ ],
  "cards": [ /* general recommendations, source: 'general' */ ],
  "query": "amazon"
}
```

## Testing
1. Restart API: `cd api && npm run dev`
2. Reload Chrome extension
3. Visit Chase offers page while signed in
4. Check API logs — should see `🔄 Syncing X offers for user Y (chase - Chase Freedom)`
5. Check Firestore Console → `offers` collection should now have documents with `cardName` and `bank` fields
6. Search: `curl http://localhost:3001/api/search?q=amazon` → returns `cards` (general)
7. Search with token → returns `personalizedOffers` too

## ⚠️ Firestore Index Required
The search query uses a compound filter (`userId` + `normalizedMerchant`). Firestore will log a link to create the required composite index the first time this query runs. Click that link to create it.