### PR TITLE
fix: update Chase DOM selectors to match actual offers page structure

### DIFF
--- a/extension/content/chase.js
+++ b/extension/content/chase.js
@@ -3,90 +3,65 @@
 // Runs automatically when user visits chase.com offers page
 // Parses offer cards from the DOM and sends to background
 // Never writes to DB directly — always via background message
+//
+// Verified selectors (March 2026):
+//   Card container : [data-testid="offer-tile-grid-item-container"]
+//   Commerce tile  : [data-testid="commerce-tile"]
+//   Merchant name  : span.mds-body-small-heavier
+//   Cashback amount: span.mds-body-large-heavier
+//   Activation     : aria-label contains "Add offer" = not activated
 // ─────────────────────────────────────────────
 
-// ── Constants ────────────────────────────────
+// ── Constants ────────────────────────────────────
 const BANK = 'chase';
-const PARSE_DELAY_MS = 2000; // Chase renders offers via React — wait for DOM to settle
+const PARSE_DELAY_MS = 2000; // Chase renders via React — wait for DOM to settle
 
-// ── Category Inference ───────────────────────
-// Chase doesn't always label categories explicitly
-// We infer from merchant name keywords as fallback
+// ── Category Inference ───────────────────────────
 const inferCategory = (merchantName) => {
   const name = merchantName.toLowerCase();
-
-  if (/restaurant|cafe|coffee|starbucks|mcdonald|chipotle|pizza|sushi|grill|diner|bistro|burger|taco|subway|panera/.test(name)) {
-    return 'dining';
-  }
-  if (/grocery|supermarket|whole foods|trader joe|kroger|safeway|wegmans|publix|aldi|costco|walmart|target/.test(name)) {
-    return 'grocery';
-  }
-  if (/shell|bp|chevron|exxon|mobil|gas|fuel|citgo|marathon|sunoco/.test(name)) {
-    return 'gas';
-  }
-  if (/cvs|walgreens|rite aid|pharmacy|drugstore/.test(name)) {
-    return 'drugstore';
-  }
-  if (/hotel|airlines|flights|marriott|hilton|hyatt|united|delta|american airlines|airbnb|expedia/.test(name)) {
-    return 'travel';
-  }
-  if (/amazon|best buy|nike|apple|walmart\.com|target\.com|ebay|etsy/.test(name)) {
-    return 'shopping';
-  }
-  if (/netflix|spotify|hulu|disney|apple tv|youtube|amazon prime/.test(name)) {
-    return 'subscription';
-  }
-
+  if (/restaurant|cafe|coffee|starbucks|mcdonald|chipotle|pizza|sushi|grill|diner|bistro|burger|taco|subway|panera/.test(name)) return 'dining';
+  if (/grocery|supermarket|whole foods|trader joe|kroger|safeway|wegmans|publix|aldi|costco|walmart|target/.test(name)) return 'grocery';
+  if (/shell|bp|chevron|exxon|mobil|gas|fuel|citgo|marathon|sunoco/.test(name)) return 'gas';
+  if (/cvs|walgreens|rite aid|pharmacy|drugstore/.test(name)) return 'drugstore';
+  if (/hotel|airlines|flights|marriott|hilton|hyatt|united|delta|american airlines|airbnb|expedia/.test(name)) return 'travel';
+  if (/amazon|best buy|nike|apple|walmart\.com|target\.com|ebay|etsy/.test(name)) return 'shopping';
+  if (/netflix|spotify|hulu|disney|apple tv|youtube|amazon prime/.test(name)) return 'subscription';
   return 'other';
 };
 
-// ── Parse Cashback Amount ─────────────────────
-// Handles formats: "$10 back", "10% back", "5% cash back"
-// Returns { cashbackAmount, cashbackType }
+// ── Parse Cashback Amount ─────────────────────────
 const parseCashback = (text) => {
   if (!text) return { cashbackAmount: 0, cashbackType: 'fixed' };
 
-  // Percent format: "5% back"
   const percentMatch = text.match(/(\d+(?:\.\d+)?)\s*%/);
   if (percentMatch) {
-    return {
-      cashbackAmount: parseFloat(percentMatch[1]),
-      cashbackType: 'percent',
-    };
+    return { cashbackAmount: parseFloat(percentMatch[1]), cashbackType: 'percent' };
   }
 
-  // Fixed format: "$10 back", "$10 statement credit"
   const fixedMatch = text.match(/\$(\d+(?:\.\d+)?)/);
   if (fixedMatch) {
-    return {
-      cashbackAmount: parseFloat(fixedMatch[1]),
-      cashbackType: 'fixed',
-    };
+    return { cashbackAmount: parseFloat(fixedMatch[1]), cashbackType: 'fixed' };
   }
 
   return { cashbackAmount: 0, cashbackType: 'fixed' };
 };
 
-// ── Parse Minimum Spend ───────────────────────
-// Handles: "on $50 or more", "when you spend $50+"
+// ── Parse Minimum Spend ───────────────────────────
 const parseMinimumSpend = (text) => {
   if (!text) return 0;
   const match = text.match(/\$(\d+(?:\.\d+)?)/);
   return match ? parseFloat(match[1]) : 0;
 };
 
-// ── Parse Expiry Date ─────────────────────────
-// Handles: "Expires 03/31/2026", "Valid through March 31, 2026"
+// ── Parse Expiry Date ─────────────────────────────
 const parseExpiry = (text) => {
   if (!text) return null;
 
-  // MM/DD/YYYY format
   const slashMatch = text.match(/(\d{1,2})\/(\d{1,2})\/(\d{4})/);
   if (slashMatch) {
     return new Date(`${slashMatch[3]}-${slashMatch[1].padStart(2,'0')}-${slashMatch[2].padStart(2,'0')}`).toISOString();
   }
 
-  // "Month DD, YYYY" format
   const wordMatch = text.match(/([A-Za-z]+)\s+(\d{1,2}),?\s+(\d{4})/);
   if (wordMatch) {
     return new Date(`${wordMatch[1]} ${wordMatch[2]}, ${wordMatch[3]}`).toISOString();
@@ -95,45 +70,38 @@ const parseExpiry = (text) => {
   return null;
 };
 
-// ── Detect Card Name ──────────────────────────
-// Chase shows card nickname in page title or account switcher
-// Falls back to generic "Chase Card" if not detectable
+// ── Detect Card Name ─────────────────────────────
 const detectCardName = () => {
-  // Try account switcher dropdown first
-  const accountEl = document.querySelector('[data-testid="account-display-name"]')
-    || document.querySelector('.account-name')
-    || document.querySelector('[class*="accountName"]');
+  // Try Chase account switcher / header elements
+  const accountEl =
+    document.querySelector('[data-testid="account-display-name"]') ||
+    document.querySelector('[data-testid="selected-account-name"]') ||
+    document.querySelector('[class*="accountName"]') ||
+    document.querySelector('[class*="account-name"]');
 
   if (accountEl?.textContent?.trim()) {
     return accountEl.textContent.trim();
   }
 
-  // Try page heading
+  // Try page heading for card name keywords
   const headingEl = document.querySelector('h1');
-  if (headingEl?.textContent?.includes('Freedom') ||
-      headingEl?.textContent?.includes('Sapphire') ||
-      headingEl?.textContent?.includes('Ink')) {
-    return headingEl.textContent.trim();
+  if (headingEl?.textContent) {
+    const text = headingEl.textContent;
+    if (/Freedom|Sapphire|Ink|Slate|Amazon|Disney|United|Marriott|Southwest/i.test(text)) {
+      return text.trim();
+    }
   }
 
   return 'Chase Card';
 };
 
-// ── Main Parser ───────────────────────────────
-// Chase renders offers as cards in a grid
-// Each offer card contains merchant name, offer description, expiry
+// ── Main Parser ─────────────────────────────────
+// Uses verified data-testid and MDS design system class selectors
 const parseChaseOffers = () => {
   const offers = [];
 
-  // Chase offer card selectors — ordered by specificity
-  // Multiple selectors handle different Chase page versions
-  const offerCards = document.querySelectorAll([
-    '[data-testid="offer-card"]',
-    '[class*="offerCard"]',
-    '[class*="offer-card"]',
-    '.offers-container .offer',
-    '[class*="OfferTile"]',
-  ].join(', '));
+  // Each offer tile sits inside this container
+  const offerCards = document.querySelectorAll('[data-testid="offer-tile-grid-item-container"]');
 
   console.log(`[RewardsFindr] Found ${offerCards.length} offer elements on Chase page`);
 
@@ -144,69 +112,57 @@ const parseChaseOffers = () => {
 
   offerCards.forEach((card, index) => {
     try {
-      // Merchant name
-      const merchantEl = card.querySelector([
-        '[data-testid="offer-merchant-name"]',
-        '[class*="merchantName"]',
-        '[class*="merchant-name"]',
-        'h3',
-        'h4',
-        '.offer-title',
-      ].join(', '));
+      const commerceTile = card.querySelector('[data-testid="commerce-tile"]');
+      if (!commerceTile) return;
 
+      // ── Merchant name ─────────────────────────────────
+      // mds-body-small-heavier = smaller merchant name text
+      const merchantEl = commerceTile.querySelector('span.mds-body-small-heavier');
       const merchantName = merchantEl?.textContent?.trim();
       if (!merchantName) {
         console.warn(`[RewardsFindr] Skipping offer ${index} — no merchant name found`);
         return;
       }
 
-      // Offer description (contains cashback amount)
-      const descEl = card.querySelector([
-        '[data-testid="offer-description"]',
-        '[class*="offerDescription"]',
-        '[class*="offer-description"]',
-        '[class*="rewardText"]',
-        'p',
-      ].join(', '));
+      // ── Cashback amount ──────────────────────────────
+      // mds-body-large-heavier = larger cashback amount text (e.g. "$100 cash back")
+      const cashbackEl = commerceTile.querySelector('span.mds-body-large-heavier');
+      const cashbackText = cashbackEl?.textContent?.trim() || '';
+      const { cashbackAmount, cashbackType } = parseCashback(cashbackText);
 
-      const description = descEl?.textContent?.trim() || '';
-      const { cashbackAmount, cashbackType } = parseCashback(description);
+      // ── Offer description ─────────────────────────────
+      // Use cashback text as description; chase doesn't show detailed description on tile
+      const offerDescription = cashbackText;
 
-      // Minimum spend
-      const minimumSpend = parseMinimumSpend(description);
+      // ── Minimum spend ────────────────────────────────
+      const minimumSpend = parseMinimumSpend(cashbackText);
 
-      // Expiry date
-      const expiryEl = card.querySelector([
-        '[data-testid="offer-expiry"]',
-        '[class*="expiryDate"]',
-        '[class*="expiry-date"]',
-        '[class*="validThrough"]',
-        '.offer-expiry',
-        'time',
-      ].join(', '));
+      // ── Activation status ─────────────────────────────
+      // aria-label contains "Add offer" when not yet activated
+      const ariaLabel = commerceTile.getAttribute('aria-label') || '';
+      const isActivated = !ariaLabel.toLowerCase().includes('add offer');
 
-      const expiryDate = parseExpiry(expiryEl?.textContent?.trim() || '');
+      // ── Activate button reference ───────────────────────
+      const activateButton = isActivated ? null : commerceTile;
 
-      // Activation status
-      const activateBtn = card.querySelector('[data-testid="activate-button"], [class*="activateBtn"], button');
-      const isActivated = activateBtn
-        ? activateBtn.textContent?.toLowerCase().includes('added') ||
-          activateBtn.textContent?.toLowerCase().includes('activated')
-        : false;
+      // ── Expiry date ──────────────────────────────────
+      // Expiry is not visible on the tile — only in detail modal
+      // Default to 90 days; API will use this if null
+      const expiryDate = null;
 
-      // Infer category from merchant name
+      // ── Category ─────────────────────────────────────
       const category = inferCategory(merchantName);
 
       offers.push({
         merchantName,
-        offerDescription: description,
+        offerDescription,
         cashbackAmount,
         cashbackType,
         minimumSpend,
         expiryDate,
         category,
         isActivated,
-        activateButton: activateBtn, // Store reference for activation
+        activateButton,
       });
 
     } catch (e) {
@@ -218,7 +174,7 @@ const parseChaseOffers = () => {
   return offers;
 };
 
-// ── Send to Background ────────────────────────
+// ── Send to Background ──────────────────────────────
 const syncOffers = (cardName, offers) => {
   chrome.runtime.sendMessage(
     {
@@ -239,37 +195,27 @@ const syncOffers = (cardName, offers) => {
   );
 };
 
-// ── Activate All Offers ───────────────────────
+// ── Activate All Offers ─────────────────────────────
 const activateAllOffers = async (offers) => {
-  const unactivatedOffers = offers.filter(o => !o.isActivated && o.activateButton);
-  
-  if (unactivatedOffers.length === 0) {
+  const unactivated = offers.filter(o => !o.isActivated && o.activateButton);
+
+  if (unactivated.length === 0) {
     alert('All offers are already activated! ✓');
     return;
   }
 
-  console.log(`[RewardsFindr] Activating ${unactivatedOffers.length} offers...`);
-  
+  console.log(`[RewardsFindr] Activating ${unactivated.length} offers...`);
   let activated = 0;
   let failed = 0;
 
-  for (const offer of unactivatedOffers) {
+  for (const offer of unactivated) {
     try {
-      // Scroll button into view
       offer.activateButton.scrollIntoView({ behavior: 'smooth', block: 'center' });
-      
-      // Wait a bit for scroll
       await new Promise(resolve => setTimeout(resolve, 300));
-      
-      // Click the activate button
       offer.activateButton.click();
-      
-      // Wait for activation to complete
       await new Promise(resolve => setTimeout(resolve, 500));
-      
       activated++;
       console.log(`[RewardsFindr] ✓ Activated: ${offer.merchantName}`);
-      
     } catch (e) {
       failed++;
       console.error(`[RewardsFindr] ✗ Failed to activate: ${offer.merchantName}`, e);
@@ -279,29 +225,25 @@ const activateAllOffers = async (offers) => {
   alert(`Activation complete!\n✓ Activated: ${activated}\n✗ Failed: ${failed}`);
 };
 
-// ── Create Floating Button ────────────────────
+// ── Create Floating Button ───────────────────────────
 const createFloatingButton = (offers) => {
-  // Remove existing button if any
   const existing = document.getElementById('rewardsfindr-activate-btn');
   if (existing) existing.remove();
 
-  // Count unactivated offers
   const unactivatedCount = offers.filter(o => !o.isActivated && o.activateButton).length;
-  
+
   if (unactivatedCount === 0) {
     console.log('[RewardsFindr] All offers already activated — not showing button');
     return;
   }
 
-  // Create button
   const button = document.createElement('button');
   button.id = 'rewardsfindr-activate-btn';
   button.innerHTML = `
     <span style="font-size: 18px; margin-right: 6px;">⚡</span>
     <span>Activate All (${unactivatedCount})</span>
   `;
-  
-  // Styles
+
   Object.assign(button.style, {
     position: 'fixed',
     bottom: '24px',
@@ -322,30 +264,24 @@ const createFloatingButton = (offers) => {
     transition: 'all 0.2s ease',
   });
 
-  // Hover effect
   button.addEventListener('mouseenter', () => {
     button.style.transform = 'translateY(-2px)';
     button.style.boxShadow = '0 12px 24px rgba(79, 70, 229, 0.4), 0 4px 8px rgba(0, 0, 0, 0.15)';
   });
-
   button.addEventListener('mouseleave', () => {
     button.style.transform = 'translateY(0)';
     button.style.boxShadow = '0 8px 16px rgba(79, 70, 229, 0.3), 0 2px 4px rgba(0, 0, 0, 0.1)';
   });
 
-  // Click handler
   button.addEventListener('click', async () => {
     button.disabled = true;
     button.style.opacity = '0.6';
     button.style.cursor = 'not-allowed';
     button.innerHTML = '<span style="font-size: 18px;">⏳</span> <span>Activating...</span>';
-    
     await activateAllOffers(offers);
-    
-    // Refresh offers after activation
     setTimeout(() => {
       button.remove();
-      boot(); // Re-run to update counts
+      boot();
     }, 1000);
   });
 
@@ -353,10 +289,7 @@ const createFloatingButton = (offers) => {
   console.log(`[RewardsFindr] ✓ Floating button added (${unactivatedCount} offers)`);
 };
 
-// ── Boot ──────────────────────────────────────
-// Chase uses React — DOM isn't ready at document_idle sometimes
-// We wait PARSE_DELAY_MS then parse once
-// MutationObserver would be more reliable but adds complexity — revisit if needed
+// ── Boot ───────────────────────────────────────────
 const boot = () => {
   console.log('[RewardsFindr] Chase content script loaded — waiting for DOM…');
 


### PR DESCRIPTION
## Problem
The Chase content script was finding 0 offers because all the CSS selectors were guesses that don't match Chase's actual DOM.

```
[RewardsFindr] Found 0 offer elements on Chase page
[RewardsFindr] No offer cards found — Chase may have updated their DOM
```

## Root Cause
Old selectors like `[data-testid="offer-card"]`, `[class*="offerCard"]`, `[class*="OfferTile"]` don't exist on the real Chase offers page.

## Fix
Verified selectors from actual Chase DOM inspection (March 2026):

| Element | Old (broken) | New (verified) |
|---------|-------------|----------------|
| Card container | `[data-testid="offer-card"]` | `[data-testid="offer-tile-grid-item-container"]` |
| Commerce tile | `[class*="offerCard"]` | `[data-testid="commerce-tile"]` |
| Merchant name | `[class*="merchantName"]`, `h3` | `span.mds-body-small-heavier` |
| Cashback amount | `[class*="rewardText"]` | `span.mds-body-large-heavier` |
| Activation status | button text check | `aria-label` contains `"Add offer"` = not activated |

## Notes
- Expiry date is **not shown on the offer tile** — only in the detail modal. Defaulting to `null` (API assigns 90-day fallback).
- `mds-body-*` classes are from Chase's MDS design system and are more stable than auto-generated CSS-in-JS class names like `r9jbijk`.
- The `aria-label` on each tile (e.g. `"1 of 129 Club Champion $100 cash back Add offer"`) is the most reliable source for activation status.