### PR TITLE
chore: update README and disable Vercel builds

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,3 @@
+# Disable Vercel builds for this monorepo
+# Web deployments are handled in rewardsfindr-web repo
+*

--- a/README.md
+++ b/README.md
@@ -4,28 +4,76 @@
 
 Find the best credit card rewards for any store. Search any merchant and instantly see which credit card gives you the highest cashback or points rate.
 
-🌐 Live at [rewardsfindr.com](https://rewardsfindr.com)
+🌐 **Website:** [rewardsfindr.com](https://rewardsfindr.com) ([web repo](https://github.com/rewardsfindr/rewardsfindr-web))  
+📱 **Mobile App:** Coming soon (iOS & Android)  
+🔌 **Browser Extension:** Chrome extension (in development)
 
-## Tech Stack
-- React (Create React App)
-- Firebase / Firestore
-- Vercel (deployment)
+## Repository Structure
+
+This is a monorepo containing multiple components of the RewardsFindr platform:
+
+```
+rewardsfindr/
+├── api/           # Backend API (Node.js/Express)
+├── mobile/        # React Native mobile app
+├── extension/     # Chrome browser extension
+├── shared/        # Shared utilities and types
+├── src/shared/    # Shared constants used across projects
+└── .github/       # CI/CD workflows
+```
+
+## Related Repositories
+
+- **[rewardsfindr-web](https://github.com/rewardsfindr/rewardsfindr-web)** - Marketing landing page (React, deployed on Vercel)
+- **[rewardsfindr-mobile](https://github.com/rewardsfindr/rewardsfindr-mobile)** - Mobile app (coming soon)
+- **[rewardsfindr-api](https://github.com/rewardsfindr/rewardsfindr-api)** - Backend API (coming soon)
 
 ## Development
 
-### Install dependencies
+### API Development
+```bash
+cd api
 npm install
+npm run dev
+```
 
-### Run the app locally
+### Mobile Development
+```bash
+cd mobile
+npm install
 npm start
+```
 
-### Run tests
-npm run test:all
-npm run test:shared
-npm run test:app
-
-### Build for production
+### Extension Development
+```bash
+cd extension
+npm install
 npm run build
+# Load unpacked extension in Chrome from extension/dist
+```
+
+## Testing
+
+```bash
+# Run all tests
+npm run test:all
+
+# Run specific test suites
+npm run test:shared
+npm run test:extension
+```
+
+## Tech Stack
+
+- **Frontend:** React, React Native
+- **Backend:** Node.js, Express, Firebase/Firestore
+- **Deployment:** Vercel (web), Firebase (backend)
+- **Testing:** Jest
 
 ## Contributing
+
 All changes must go through a pull request. Direct commits to main are not allowed.
+
+## Contact
+
+📧 hello@rewardsfindr.com


### PR DESCRIPTION
## Changes

### 1. ✅ Updated README.md
- Clarified this is a **monorepo** for API, Mobile, Extension
- Added repository structure section
- Linked to separate `rewardsfindr-web` repo for website
- Added development instructions for each component
- Removed web-specific dev instructions (npm start for React)
- Modernized format with emojis and clear sections

### 2. ✅ Added .vercelignore
- **Stops Vercel from building this repo**
- The web deployment now happens in `rewardsfindr-web` repo
- Prevents duplicate/unnecessary builds

## Why This Change?

The main repo is now a **monorepo** containing:
- Backend API
- Mobile app
- Browser extension
- Shared utilities

The **web landing page** has been moved to its own repo and is deployed separately.

## Testing

- ✅ README clearly explains repo structure
- ✅ Links to web repo are correct
- ✅ `.vercelignore` will prevent builds (test after merge)

## Additional Step (If Needed)

If Vercel still tries to build after merge:
1. Go to Vercel dashboard → rewardsfindr project
2. Settings → Git → **Disconnect** this repo
3. Vercel should only be connected to `rewardsfindr-web` repo