### PR TITLE
chore: tech debt cleanup

### DIFF
--- a/mobile/app/index.js
+++ b/mobile/app/index.js
@@ -73,13 +73,6 @@ export default function HomeScreen() {
     }
   };
 
-  // Called after all cards synced: totalSynced (int), cardResults ([{ cardName, count }])
-  const handleSyncSuccess = (totalSynced, cardResults) => {
-    // Modal stays open and shows Done button — no alert needed here.
-    // This callback is fired so parent knows sync is complete.
-    // The modal itself handles the Done / Go Back UI.
-  };
-
   const isSearching = searching || localSearching;
 
   return (
@@ -173,12 +166,11 @@ export default function HomeScreen() {
 
       </ScrollView>
 
-      {/* WebView Sync Modal */}
       <SyncWebView
         visible={syncBank !== null}
         bank={syncBank}
         onClose={() => setSyncBank(null)}
-        onSuccess={handleSyncSuccess}
+        onSuccess={() => {}}
       />
     </SafeAreaView>
   );

--- a/mobile/components/SyncWebView.js
+++ b/mobile/components/SyncWebView.js
@@ -31,12 +31,10 @@ const BANK_CONFIG = {
   },
   amex: {
     url: 'https://www.americanexpress.com/en-us/benefits/offers/',
-    offersUrl: null,
     label: 'Amex Offers',
     color: '#007ac1',
     offersPaths: ['/benefits/offers'],
     loginPaths: ['/login', '/sign-in', '/identity', '/auth', '/challenge'],
-    gridSelector: null,
   },
 };
 
@@ -224,7 +222,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
     try {
       const data = JSON.parse(event.nativeEvent.data);
 
-      // ── Card detection ──────────────────────────────────────
       if (data.type === 'CARDS_DETECTED') {
         if (!cardsDiscovered.current && data.cards && data.cards.length > 0) {
           cardOptionsRef.current  = data.cards;
@@ -238,7 +235,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         return;
       }
 
-      // ── Card switched → wait for grid then capture ──────────
       if (data.type === 'CARD_SWITCHED') {
         const expectedIndex = data.expectedIndex;
         const expectedLabel = cardOptionsRef.current.find(c => c.index === expectedIndex)?.label || '';


### PR DESCRIPTION
## What
Minimal dead code and comment cleanup across `mobile/`.

## Changes

### `mobile/components/SyncWebView.js`
- Removed unused `offersUrl: null` and `gridSelector: null` from Amex `BANK_CONFIG` (stubs with no functional effect)
- Removed section divider comments in `handleMessage` (code is self-explanatory)

### `mobile/app/index.js`
- Removed unused `handleSyncSuccess` function (was a no-op with dead comments)
- Inlined `onSuccess={() => {}}` directly in `<SyncWebView />` prop

## Not changed
- `api/deleteOffers.js` — kept intentionally per discussion
- `api/routes/offers.js` — `/sync` route kept (Chrome extension dependency)
- All test files, parsers, and routes untouched

## Risk
No logic changes — comments and dead stubs only.