### PR TITLE
fix: full bank label and activated indicator on results screen

### DIFF
--- a/mobile/app/results.js
+++ b/mobile/app/results.js
@@ -140,7 +140,7 @@ export default function ResultsScreen() {
 
             {sorted.map((offer, idx) => {
               const barWidth = `${Math.round(((parseFloat(offer.cashbackAmount) || 0) / maxPct) * 100)}%`;
-              const isActivated = offer.activated === true;
+              const isActivated = offer.isActivated === true;
               return (
                 <TouchableOpacity
                   key={offer.offerId || idx}


### PR DESCRIPTION
## Changes
- **Fix bank label cutoff**: Removed `.slice(0, 4)` from `bankPillSm` — now shows full label (e.g. `CHASE` instead of `CHAS`)
- **Activated indicator**: Added green `✓ ACTIVATED` badge next to card name when `offer.activated === true`
- **Green progress bar**: Bar turns green for activated offers for extra visual clarity
- Added `flexWrap: 'wrap'` to `rankNameRow` so badges don't overflow on long card names