### PR TITLE
feat: Amex offer sync + refactor SyncWebView into sync/ modules

### DIFF
--- a/api/lib/parsers/amex.js
+++ b/api/lib/parsers/amex.js
@@ -61,9 +61,10 @@ export function parseAmexOffers(html) {
       let cashbackAmount = 0;
       let cashbackType   = 'fixed';
 
-      const pointsMatch  = searchText.match(/[Ee]arn\s+([\d,]+(?:\.\d+)?)\s+[Mm]embership\s+[Rr]ewards/);
+      // Handle "Earn +5 Membership Rewards" or "earn 10,000 Membership Rewards"
+      const pointsMatch  = searchText.match(/[Ee]arn\s+\+?([\d,]+(?:\.\d+)?)\s+[Mm]embership\s+[Rr]ewards/);
       const percentMatch = searchText.match(/([\d.]+)%\s+back/);
-      // Match last dollar amount after "earn" (handles "earn $10 back", "earn $25")
+      // Match dollar amount after "earn" (handles "earn $10 back", "earn $25")
       const dollarMatch  = searchText.match(/[Ee]arn\s+\$([0-9,]+(?:\.[0-9]+)?)/);
 
       if (pointsMatch) {

--- a/api/lib/parsers/amex.js
+++ b/api/lib/parsers/amex.js
@@ -24,19 +24,14 @@ export function parseAmexOffers(html) {
   const $ = cheerio.load(html);
   const offers = [];
 
-  // Determine row set:
-  // Case 1: captured HTML is outerHTML of listViewContainer itself (root element)
-  // Case 2: captured HTML is a larger page containing listViewContainer
   let $rows;
   const $root = $.root().children().first();
   const isRootListView = $root.attr('data-testid') === 'listViewContainer';
 
   if (isRootListView) {
-    // Root IS the container — rows are its direct children
     $rows = $root.children('div');
     console.log(`[parseAmexOffers] root IS listViewContainer, direct div children: ${$rows.length}`);
   } else {
-    // Full page — find container then its children
     $rows = $('[data-testid="listViewContainer"]').first().children('div');
     console.log(`[parseAmexOffers] full page mode, listViewContainer children: ${$rows.length}`);
   }
@@ -60,29 +55,34 @@ export function parseAmexOffers(html) {
       const offerDescription = descContainers.eq(1).text().trim() || offerTitle;
 
       // ── Cashback Parsing ─────────────────────────────
+      // Search both title and description; description usually has the cashback value
+      const searchText = offerTitle + ' ' + offerDescription;
+
       let cashbackAmount = 0;
       let cashbackType   = 'fixed';
 
-      const pointsMatch  = offerTitle.match(/[Ee]arn\s+(\d+(?:\.\d+)?)\s+[Mm]embership\s+[Rr]ewards/);
-      const percentMatch = offerTitle.match(/(\d+(?:\.\d+)?)%/);
-      const dollarMatch  = offerTitle.match(/\$([\d.]+)/);
+      const pointsMatch  = searchText.match(/[Ee]arn\s+([\d,]+(?:\.\d+)?)\s+[Mm]embership\s+[Rr]ewards/);
+      const percentMatch = searchText.match(/([\d.]+)%\s+back/);
+      // Match last dollar amount after "earn" (handles "earn $10 back", "earn $25")
+      const dollarMatch  = searchText.match(/[Ee]arn\s+\$([0-9,]+(?:\.[0-9]+)?)/);
 
       if (pointsMatch) {
-        cashbackAmount = parseFloat(pointsMatch[1]);
+        cashbackAmount = parseFloat(pointsMatch[1].replace(/,/g, ''));
         cashbackType   = 'points';
       } else if (percentMatch) {
         cashbackAmount = parseFloat(percentMatch[1]);
         cashbackType   = 'percent';
       } else if (dollarMatch) {
-        cashbackAmount = parseFloat(dollarMatch[1]);
+        cashbackAmount = parseFloat(dollarMatch[1].replace(/,/g, ''));
         cashbackType   = 'fixed';
       }
 
       // ── Minimum Spend ────────────────────────────────
       let minimumSpend = 0;
-      const combinedText  = (offerTitle + ' ' + offerDescription).toLowerCase();
-      const minSpendMatch = combinedText.match(/spend\s+\$?([\d.]+)/);
-      if (minSpendMatch) minimumSpend = parseFloat(minSpendMatch[1]);
+      const combinedText  = searchText.toLowerCase();
+      // Strip commas from amounts like $1,000
+      const minSpendMatch = combinedText.match(/spend\s+\$?([\d,]+(?:\.\d+)?)/);
+      if (minSpendMatch) minimumSpend = parseFloat(minSpendMatch[1].replace(/,/g, ''));
 
       // ── Expiry Date ──────────────────────────────────
       let expiryDate    = null;

--- a/api/lib/parsers/amex.js
+++ b/api/lib/parsers/amex.js
@@ -11,6 +11,12 @@
 //       ├─ h3                                           ← merchant name
 //       ├─ [data-testid="overflowTextContainer"] x2     ← [0]=title [1]=description
 //       └─ <p> containing "Expires"                     ← expiry
+//
+// NOTE: captureJs grabs outerHTML of listViewContainer, so when Cheerio
+// loads it the ROOT element IS listViewContainer — we can't use a
+// descendant selector to find it. We detect both cases:
+//   1. Root IS listViewContainer → select its direct > div children
+//   2. Root is a full page       → find listViewContainer then its > div children
 // ─────────────────────────────────────────────
 import * as cheerio from 'cheerio';
 
@@ -18,15 +24,28 @@ export function parseAmexOffers(html) {
   const $ = cheerio.load(html);
   const offers = [];
 
-  // Each offer is a direct DIV child of listViewContainer.
-  // There are no data-testid or stable class names on the row itself.
-  $('[data-testid="listViewContainer"] > div').each((i, el) => {
+  // Determine row set:
+  // Case 1: captured HTML is outerHTML of listViewContainer itself (root element)
+  // Case 2: captured HTML is a larger page containing listViewContainer
+  let $rows;
+  const $root = $.root().children().first();
+  const isRootListView = $root.attr('data-testid') === 'listViewContainer';
+
+  if (isRootListView) {
+    // Root IS the container — rows are its direct children
+    $rows = $root.children('div');
+    console.log(`[parseAmexOffers] root IS listViewContainer, direct div children: ${$rows.length}`);
+  } else {
+    // Full page — find container then its children
+    $rows = $('[data-testid="listViewContainer"]').first().children('div');
+    console.log(`[parseAmexOffers] full page mode, listViewContainer children: ${$rows.length}`);
+  }
+
+  $rows.each((i, el) => {
     try {
       const $el = $(el);
 
       // ── Filter: skip bank/promo tiles ────────────────────
-      // Real merchant offers always have either the add button OR success icon.
-      // Bank promos (Savings, Loans, CreditSecure) have neither.
       const isAddable   = $el.find('[data-testid="merchantOfferListAddButton"]').length > 0;
       const isActivated = $el.find('[data-testid="merchantOfferSuccessIcon"]').length > 0;
       if (!isAddable && !isActivated) return;
@@ -36,41 +55,37 @@ export function parseAmexOffers(html) {
       if (!merchantName) return;
 
       // ── Offer Title + Description ───────────────────────
-      // First overflowTextContainer = short title (e.g. "Earn $10 back")
-      // Second overflowTextContainer = terms (e.g. "Spend $50 or more")
-      const descContainers = $el.find('[data-testid="overflowTextContainer"]');
+      const descContainers   = $el.find('[data-testid="overflowTextContainer"]');
       const offerTitle       = descContainers.eq(0).text().trim();
       const offerDescription = descContainers.eq(1).text().trim() || offerTitle;
 
       // ── Cashback Parsing ─────────────────────────────
-      // Parse from the title which is most concise
       let cashbackAmount = 0;
-      let cashbackType = 'fixed';
+      let cashbackType   = 'fixed';
 
-      const pointsMatch   = offerTitle.match(/[Ee]arn\s+(\d+(?:\.\d+)?)\s+[Mm]embership\s+[Rr]ewards/);
-      const percentMatch  = offerTitle.match(/(\d+(?:\.\d+)?)%/);
-      const dollarMatch   = offerTitle.match(/\$([\d.]+)/);
+      const pointsMatch  = offerTitle.match(/[Ee]arn\s+(\d+(?:\.\d+)?)\s+[Mm]embership\s+[Rr]ewards/);
+      const percentMatch = offerTitle.match(/(\d+(?:\.\d+)?)%/);
+      const dollarMatch  = offerTitle.match(/\$([\d.]+)/);
 
       if (pointsMatch) {
         cashbackAmount = parseFloat(pointsMatch[1]);
-        cashbackType = 'points';
+        cashbackType   = 'points';
       } else if (percentMatch) {
         cashbackAmount = parseFloat(percentMatch[1]);
-        cashbackType = 'percent';
+        cashbackType   = 'percent';
       } else if (dollarMatch) {
         cashbackAmount = parseFloat(dollarMatch[1]);
-        cashbackType = 'fixed';
+        cashbackType   = 'fixed';
       }
 
       // ── Minimum Spend ────────────────────────────────
       let minimumSpend = 0;
-      const combinedText = (offerTitle + ' ' + offerDescription).toLowerCase();
+      const combinedText  = (offerTitle + ' ' + offerDescription).toLowerCase();
       const minSpendMatch = combinedText.match(/spend\s+\$?([\d.]+)/);
       if (minSpendMatch) minimumSpend = parseFloat(minSpendMatch[1]);
 
       // ── Expiry Date ──────────────────────────────────
-      // Format: "Expires 4/2/26"
-      let expiryDate = null;
+      let expiryDate    = null;
       let isExpiringSoon = false;
 
       const $expiryP = $el.find('p').filter((_, p) =>
@@ -84,7 +99,7 @@ export function parseAmexOffers(html) {
         if (parts.length === 3) {
           const [m, d, y] = parts;
           const fullYear = parseInt(y) < 100 ? 2000 + parseInt(y) : parseInt(y);
-          const parsed = new Date(fullYear, parseInt(m) - 1, parseInt(d));
+          const parsed   = new Date(fullYear, parseInt(m) - 1, parseInt(d));
           if (!isNaN(parsed.getTime())) expiryDate = parsed.toISOString();
         }
       }
@@ -105,6 +120,6 @@ export function parseAmexOffers(html) {
     }
   });
 
-  console.log(`[parseAmexOffers] total rows scanned: ${$('[data-testid="listViewContainer"] > div').length}, offers parsed: ${offers.length}`);
+  console.log(`[parseAmexOffers] offers parsed: ${offers.length}`);
   return offers;
 }

--- a/api/lib/parsers/amex.js
+++ b/api/lib/parsers/amex.js
@@ -2,12 +2,20 @@
 // AMEX OFFERS PARSER
 // Parses raw HTML from the Amex Offers & Benefits page.
 // Selectors target americanexpress.com/en-us/benefits/offers/
-// and may need tuning as Amex updates their frontend.
+// DOM analysis: Mar 2026
 // ─────────────────────────────────────────────
 import * as cheerio from 'cheerio';
 
 /**
  * Parse raw Amex offers page HTML into a normalized offer array.
+ * Only includes real merchant offers (ignores bank/promo tiles).
+ *
+ * HOW TO DISTINGUISH MERCHANT OFFERS FROM BANK PROMOS:
+ *   - Merchant (not yet activated): has [data-testid="merchantOfferListAddButton"]
+ *   - Merchant (already activated): has [data-testid="merchantOfferSuccessIcon"]
+ *   - Bank/promo tiles (e.g. Amex Savings, Loans, CreditSecure): have neither.
+ *     They use [data-testid="cardOfferLearnLink"] instead.
+ *
  * @param {string} html - Raw outerHTML captured from the Amex offers page
  * @returns {Array} offers - Array of normalized offer objects
  */
@@ -15,93 +23,84 @@ export function parseAmexOffers(html) {
   const $ = cheerio.load(html);
   const offers = [];
 
-  // Amex renders offer cards in a grid. Try multiple selector strategies.
-  const cardSelector = [
-    '[data-module-name="offer-module"]',
-    '[class*="OfferCard"]',
-    '[class*="offer-card"]',
-    '.offer-card',
-    '[data-testid="offer-card"]',
-  ].join(', ');
-
-  $(cardSelector).each((i, el) => {
+  // All offer rows (merchant + bank promos) share this class pattern
+  $('[class*="listViewRow"]').each((i, el) => {
     try {
       const $el = $(el);
 
+      // ── Filter: skip bank/promo offers ─────────────
+      // Merchant offers always have either the add button OR the success icon.
+      // Bank promos (Savings, Loans, CreditSecure, card referrals) have neither.
+      const isAddable   = $el.find('[data-testid="merchantOfferListAddButton"]').length > 0;
+      const isActivated = $el.find('[data-testid="merchantOfferSuccessIcon"]').length > 0;
+      if (!isAddable && !isActivated) return;
+
       // ── Merchant Name ──────────────────────────────
-      const merchantName = $el
-        .find(
-          '[class*="merchant"], [class*="Merchant"], [class*="brand"], [class*="Brand"], .offer-merchant-name'
-        )
-        .first()
-        .text()
-        .trim();
+      // The merchant name lives in the first <h3> inside the row
+      const merchantName = $el.find('h3').first().text().trim();
+      if (!merchantName) return;
 
-      if (!merchantName) return; // skip cards without a merchant
+      // ── Offer Description ──────────────────────────
+      // Second [data-testid="overflowTextContainer"] holds the deal text
+      const descContainers = $el.find('[data-testid="overflowTextContainer"]');
+      const offerDescription = descContainers.eq(1).text().trim();
 
-      // ── Offer Value ────────────────────────────────
-      const valueText = $el
-        .find(
-          '[class*="offer-value"], [class*="OfferValue"], [class*="cashback"], [class*="Cashback"], .offer-title, [class*="headline"]'
-        )
-        .first()
-        .text()
-        .trim();
-
+      // ── Cashback Parsing ───────────────────────────
+      // Amex descriptions follow patterns like:
+      //   "Spend $50 or more, earn $10 back"
+      //   "Earn 6 Membership Rewards points per eligible dollar spent"
+      //   "Earn 10 back on purchases"
       let cashbackAmount = 0;
-      let cashbackType = 'fixed'; // Amex is usually fixed $ amounts
+      let cashbackType = 'fixed';
+      const descLower = offerDescription.toLowerCase();
 
-      const percentMatch = valueText.match(/(\d+(?:\.\d+)?)\s*%/);
-      const dollarMatch = valueText.match(/\$(\d+(?:\.\d+)?)/);
+      // Points offers (e.g. "Earn 6 Membership Rewards points")
+      const pointsMatch = offerDescription.match(/[Ee]arn\s+(\d+(?:\.\d+)?)\s+[Mm]embership\s+[Rr]ewards/);
+      // Percent back offers (e.g. "Earn 10% back")
+      const percentMatch = offerDescription.match(/(\d+(?:\.\d+)?)%/);
+      // Fixed dollar back offers (e.g. "earn $25 back", "earn 10 back")
+      const dollarBackMatch = offerDescription.match(/earn\s+\$?(\d+(?:\.\d+)?)\s+back/i);
 
-      if (percentMatch) {
+      if (pointsMatch) {
+        cashbackAmount = parseFloat(pointsMatch[1]);
+        cashbackType = 'points';
+      } else if (percentMatch) {
         cashbackAmount = parseFloat(percentMatch[1]);
         cashbackType = 'percent';
-      } else if (dollarMatch) {
-        cashbackAmount = parseFloat(dollarMatch[1]);
+      } else if (dollarBackMatch) {
+        cashbackAmount = parseFloat(dollarBackMatch[1]);
         cashbackType = 'fixed';
       }
 
-      // ── Description / Terms ────────────────────────
-      const offerDescription = $el
-        .find(
-          '[class*="terms"], [class*="Terms"], [class*="description"], [class*="Description"], [class*="subtitle"]'
-        )
-        .first()
-        .text()
-        .trim();
-
       // ── Minimum Spend ──────────────────────────────
+      // e.g. "Spend $50 or more" or "Spend 125 or more"
       let minimumSpend = 0;
-      const combinedText = (valueText + ' ' + offerDescription).toLowerCase();
-      const minSpendMatch = combinedText.match(/(?:spend|purchase|shop)\s+\$?(\d+)/);
+      const minSpendMatch = descLower.match(/spend\s+\$?(\d+)/);
       if (minSpendMatch) minimumSpend = parseFloat(minSpendMatch[1]);
 
       // ── Expiry Date ────────────────────────────────
-      const expiryText = $el
-        .find(
-          '[class*="expir"], [class*="Expir"], [class*="valid"], [class*="Valid"], [class*="date"], [class*="Date"]'
-        )
-        .first()
-        .text()
-        .trim();
-
+      // Expiry lives in a <p> tag directly inside the offer content area.
+      // Format from DOM: "Expires 4/2/26" or "Expires 12/30/25"
+      // Near-expiry rows use class containing "color-status-text-critical"
       let expiryDate = null;
-      if (expiryText) {
-        const cleaned = expiryText
-          .replace(/(?:valid through|expires?|through|by)/i, '')
-          .trim();
-        const parsed = new Date(cleaned);
-        if (!isNaN(parsed.getTime())) expiryDate = parsed.toISOString();
-      }
+      let isExpiringSoon = false;
 
-      // ── Activation Status ──────────────────────────
-      const btnText = $el.find('button, [role="button"]').text().toLowerCase();
-      const isActivated =
-        btnText.includes('added') ||
-        btnText.includes('enrolled') ||
-        btnText.includes('remove') ||
-        $el.find('[class*="enrolled"], [class*="activated"], [class*="added"]').length > 0;
+      const $expiryP = $el.find('p').filter((_, p) => {
+        return $(p).text().toLowerCase().includes('expires');
+      }).first();
+
+      if ($expiryP.length) {
+        isExpiringSoon = ($expiryP.attr('class') || '').includes('color-status-text-critical');
+        const rawExpiry = $expiryP.text().replace(/expires/i, '').trim();
+        // rawExpiry is like "4/2/26" — parse as M/D/YY
+        const parts = rawExpiry.split('/');
+        if (parts.length === 3) {
+          const [m, d, y] = parts;
+          const fullYear = parseInt(y) < 100 ? 2000 + parseInt(y) : parseInt(y);
+          const parsed = new Date(fullYear, parseInt(m) - 1, parseInt(d));
+          if (!isNaN(parsed.getTime())) expiryDate = parsed.toISOString();
+        }
+      }
 
       offers.push({
         merchantName,
@@ -109,12 +108,13 @@ export function parseAmexOffers(html) {
         cashbackAmount,
         cashbackType,
         minimumSpend,
-        category: 'other', // TODO: infer from merchant if needed
+        category: 'other',
         expiryDate,
         isActivated,
+        isExpiringSoon,
       });
     } catch (err) {
-      console.error('⚠️ Error parsing Amex offer card:', err);
+      console.error('⚠️ Error parsing Amex offer row:', err);
     }
   });
 

--- a/api/lib/parsers/amex.js
+++ b/api/lib/parsers/amex.js
@@ -1,65 +1,55 @@
 // ─────────────────────────────────────────────
 // AMEX OFFERS PARSER
-// Parses raw HTML from the Amex Offers & Benefits page.
-// Selectors target americanexpress.com/en-us/benefits/offers/
+// Parses raw HTML from global.americanexpress.com/offers/eligible
 // DOM analysis: Mar 2026
+//
+// Structure:
+//   [data-testid="listViewContainer"]
+//     > DIV  (one per offer, no data-testid on row itself)
+//       ├─ [data-testid="merchantOfferListAddButton"]   ← not yet added
+//       ├─ [data-testid="merchantOfferSuccessIcon"]     ← already added
+//       ├─ h3                                           ← merchant name
+//       ├─ [data-testid="overflowTextContainer"] x2     ← [0]=title [1]=description
+//       └─ <p> containing "Expires"                     ← expiry
 // ─────────────────────────────────────────────
 import * as cheerio from 'cheerio';
 
-/**
- * Parse raw Amex offers page HTML into a normalized offer array.
- * Only includes real merchant offers (ignores bank/promo tiles).
- *
- * HOW TO DISTINGUISH MERCHANT OFFERS FROM BANK PROMOS:
- *   - Merchant (not yet activated): has [data-testid="merchantOfferListAddButton"]
- *   - Merchant (already activated): has [data-testid="merchantOfferSuccessIcon"]
- *   - Bank/promo tiles (e.g. Amex Savings, Loans, CreditSecure): have neither.
- *     They use [data-testid="cardOfferLearnLink"] instead.
- *
- * @param {string} html - Raw outerHTML captured from the Amex offers page
- * @returns {Array} offers - Array of normalized offer objects
- */
 export function parseAmexOffers(html) {
   const $ = cheerio.load(html);
   const offers = [];
 
-  // All offer rows (merchant + bank promos) share this class pattern
-  $('[class*="listViewRow"]').each((i, el) => {
+  // Each offer is a direct DIV child of listViewContainer.
+  // There are no data-testid or stable class names on the row itself.
+  $('[data-testid="listViewContainer"] > div').each((i, el) => {
     try {
       const $el = $(el);
 
-      // ── Filter: skip bank/promo offers ─────────────
-      // Merchant offers always have either the add button OR the success icon.
-      // Bank promos (Savings, Loans, CreditSecure, card referrals) have neither.
+      // ── Filter: skip bank/promo tiles ────────────────────
+      // Real merchant offers always have either the add button OR success icon.
+      // Bank promos (Savings, Loans, CreditSecure) have neither.
       const isAddable   = $el.find('[data-testid="merchantOfferListAddButton"]').length > 0;
       const isActivated = $el.find('[data-testid="merchantOfferSuccessIcon"]').length > 0;
       if (!isAddable && !isActivated) return;
 
-      // ── Merchant Name ──────────────────────────────
-      // The merchant name lives in the first <h3> inside the row
+      // ── Merchant Name ─────────────────────────────────
       const merchantName = $el.find('h3').first().text().trim();
       if (!merchantName) return;
 
-      // ── Offer Description ──────────────────────────
-      // Second [data-testid="overflowTextContainer"] holds the deal text
+      // ── Offer Title + Description ───────────────────────
+      // First overflowTextContainer = short title (e.g. "Earn $10 back")
+      // Second overflowTextContainer = terms (e.g. "Spend $50 or more")
       const descContainers = $el.find('[data-testid="overflowTextContainer"]');
-      const offerDescription = descContainers.eq(1).text().trim();
+      const offerTitle       = descContainers.eq(0).text().trim();
+      const offerDescription = descContainers.eq(1).text().trim() || offerTitle;
 
-      // ── Cashback Parsing ───────────────────────────
-      // Amex descriptions follow patterns like:
-      //   "Spend $50 or more, earn $10 back"
-      //   "Earn 6 Membership Rewards points per eligible dollar spent"
-      //   "Earn 10 back on purchases"
+      // ── Cashback Parsing ─────────────────────────────
+      // Parse from the title which is most concise
       let cashbackAmount = 0;
       let cashbackType = 'fixed';
-      const descLower = offerDescription.toLowerCase();
 
-      // Points offers (e.g. "Earn 6 Membership Rewards points")
-      const pointsMatch = offerDescription.match(/[Ee]arn\s+(\d+(?:\.\d+)?)\s+[Mm]embership\s+[Rr]ewards/);
-      // Percent back offers (e.g. "Earn 10% back")
-      const percentMatch = offerDescription.match(/(\d+(?:\.\d+)?)%/);
-      // Fixed dollar back offers (e.g. "earn $25 back", "earn 10 back")
-      const dollarBackMatch = offerDescription.match(/earn\s+\$?(\d+(?:\.\d+)?)\s+back/i);
+      const pointsMatch   = offerTitle.match(/[Ee]arn\s+(\d+(?:\.\d+)?)\s+[Mm]embership\s+[Rr]ewards/);
+      const percentMatch  = offerTitle.match(/(\d+(?:\.\d+)?)%/);
+      const dollarMatch   = offerTitle.match(/\$([\d.]+)/);
 
       if (pointsMatch) {
         cashbackAmount = parseFloat(pointsMatch[1]);
@@ -67,32 +57,29 @@ export function parseAmexOffers(html) {
       } else if (percentMatch) {
         cashbackAmount = parseFloat(percentMatch[1]);
         cashbackType = 'percent';
-      } else if (dollarBackMatch) {
-        cashbackAmount = parseFloat(dollarBackMatch[1]);
+      } else if (dollarMatch) {
+        cashbackAmount = parseFloat(dollarMatch[1]);
         cashbackType = 'fixed';
       }
 
-      // ── Minimum Spend ──────────────────────────────
-      // e.g. "Spend $50 or more" or "Spend 125 or more"
+      // ── Minimum Spend ────────────────────────────────
       let minimumSpend = 0;
-      const minSpendMatch = descLower.match(/spend\s+\$?(\d+)/);
+      const combinedText = (offerTitle + ' ' + offerDescription).toLowerCase();
+      const minSpendMatch = combinedText.match(/spend\s+\$?([\d.]+)/);
       if (minSpendMatch) minimumSpend = parseFloat(minSpendMatch[1]);
 
-      // ── Expiry Date ────────────────────────────────
-      // Expiry lives in a <p> tag directly inside the offer content area.
-      // Format from DOM: "Expires 4/2/26" or "Expires 12/30/25"
-      // Near-expiry rows use class containing "color-status-text-critical"
+      // ── Expiry Date ──────────────────────────────────
+      // Format: "Expires 4/2/26"
       let expiryDate = null;
       let isExpiringSoon = false;
 
-      const $expiryP = $el.find('p').filter((_, p) => {
-        return $(p).text().toLowerCase().includes('expires');
-      }).first();
+      const $expiryP = $el.find('p').filter((_, p) =>
+        $(p).text().toLowerCase().includes('expires')
+      ).first();
 
       if ($expiryP.length) {
         isExpiringSoon = ($expiryP.attr('class') || '').includes('color-status-text-critical');
         const rawExpiry = $expiryP.text().replace(/expires/i, '').trim();
-        // rawExpiry is like "4/2/26" — parse as M/D/YY
         const parts = rawExpiry.split('/');
         if (parts.length === 3) {
           const [m, d, y] = parts;
@@ -118,5 +105,6 @@ export function parseAmexOffers(html) {
     }
   });
 
+  console.log(`[parseAmexOffers] total rows scanned: ${$('[data-testid="listViewContainer"] > div').length}, offers parsed: ${offers.length}`);
   return offers;
 }

--- a/api/routes/offers.js
+++ b/api/routes/offers.js
@@ -155,10 +155,25 @@ router.post('/parse', async (req, res) => {
       return res.status(400).json({ error: "bank must be 'chase' or 'amex'" });
     }
 
+    // DEBUG: log incoming HTML stats
+    console.log(`📥 [parse] bank=${bank} cardName=${cardName} html.length=${html.length}`);
+    console.log(`📥 [parse] html snippet (first 300 chars):`, html.substring(0, 300));
+
+    // DEBUG: check if key Amex selectors are present in the HTML
+    if (bank === 'amex') {
+      console.log(`🔍 [parse:amex] listViewRow count:`, (html.match(/listViewRow/g) || []).length);
+      console.log(`🔍 [parse:amex] merchantOfferListAddButton count:`, (html.match(/merchantOfferListAddButton/g) || []).length);
+      console.log(`🔍 [parse:amex] merchantOfferSuccessIcon count:`, (html.match(/merchantOfferSuccessIcon/g) || []).length);
+      console.log(`🔍 [parse:amex] listViewContainer present:`, html.includes('listViewContainer'));
+    }
+
     const parseFn = bank === 'chase' ? parseChaseOffers : parseAmexOffers;
     const offers = parseFn(html);
 
-    console.log(`🔍 Parsed ${offers.length} offers from ${bank} HTML for user ${userId}`);
+    console.log(`🔍 [parse] parsed ${offers.length} offers from ${bank} HTML for user ${userId}`);
+    if (offers.length > 0) {
+      console.log(`🔍 [parse] first offer sample:`, JSON.stringify(offers[0]));
+    }
 
     if (offers.length === 0) {
       return res.json({ success: true, offers: [], synced: 0, bank, message: 'No offers found in provided HTML.' });
@@ -167,7 +182,7 @@ router.post('/parse', async (req, res) => {
     const resolvedCardName = cardName || (bank === 'chase' ? 'Chase Card' : 'Amex Card');
     const { syncedCount, skippedCount } = await writeOffersToDB(offers, { userId, bank, cardName: resolvedCardName });
 
-    console.log(`✅ Parse+sync complete: ${syncedCount} synced, ${skippedCount} skipped (${bank} — ${resolvedCardName})`);
+    console.log(`✅ [parse] Parse+sync complete: ${syncedCount} synced, ${skippedCount} skipped (${bank} — ${resolvedCardName})`);
 
     res.json({ success: true, offers, synced: syncedCount, skipped: skippedCount, bank, cardName: resolvedCardName });
   } catch (error) {

--- a/mobile/components/SyncWebView.js
+++ b/mobile/components/SyncWebView.js
@@ -1,15 +1,18 @@
 // ─────────────────────────────────────────────────────────────────
-// SYNC WEBVIEW MODAL
-// Footer states:
-//   0. Not ready → nothing shown
-//   1. Ready, not on offers page → "Go to Offers Page" button
-//   2. On offers page → "Sync Offers" button
-//   3. Sync in progress → spinner + status text
-//   4. All done → auto-close
+// SYNC WEBVIEW MODAL — orchestrator
+// Handles modal UI, state, and message routing.
+// Bank-specific JS injection is in sync/ modules.
 //
-// "ready" for Chase = onOffersPage (CARDS_DETECTED with cards)
-// "ready" for others = pageLoaded AND onOffersPage (URL-based)
-// This handles Chase SPA where CARDS_DETECTED fires before onLoadEnd.
+// Footer states:
+//   0. Not ready         → nothing
+//   1. On offers page    → "Sync Offers" button
+//   2. Page loaded, not on offers page → "Go to Offers Page"
+//   3. Sync in progress  → spinner + status
+//
+// Adding a new bank:
+//   1. Add entry to sync/bankConfig.js
+//   2. Create sync/<bank>Sync.js with detect + switch JS
+//   3. Wire up in handleLoadEnd + handleMessage below
 // ─────────────────────────────────────────────────────────────────
 import React, { useRef, useState, useEffect } from 'react';
 import {
@@ -20,154 +23,27 @@ import { WebView } from 'react-native-webview';
 import { getAuthInstance } from '../lib/firebaseClient.js';
 import { colors, radii } from '../shared/theme.js';
 
-const CHASE_OFFERS_URL = 'https://secure.chase.com/web/auth/dashboard#/dashboard/merchantOffers/offer-hub';
+import { BANK_CONFIG }             from './sync/bankConfig.js';
+import { DETECT_CARDS_JS, buildSwitchCardJs } from './sync/chaseSync.js';
+import { AMEX_OPEN_AND_DETECT_JS, buildAmexSwitchCardJs } from './sync/amexSync.js';
+import { buildCaptureJs, parseCardLabel } from './sync/captureJs.js';
 
-const BANK_CONFIG = {
-  chase: {
-    url: CHASE_OFFERS_URL,
-    offersUrl: CHASE_OFFERS_URL,
-    label: 'Chase Offers',
-    color: '#1a3a6b',
-    offersPaths: ['/cardmember-offers', 'merchantOffers'],
-    loginPaths: ['/sign-in', '/logon', '/login', '/sso', '/identify', '/challenge'],
-    gridSelector: '[data-testid="grid-items-container"]',
-    useCardsDetectedAsOffersSignal: true,
-  },
-  amex: {
-    url: 'https://www.americanexpress.com/en-us/benefits/offers/',
-    label: 'Amex Offers',
-    color: '#007ac1',
-    offersPaths: ['/benefits/offers'],
-    loginPaths: ['/login', '/sign-in', '/identity', '/auth', '/challenge'],
-  },
-};
-
-const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3001';
+const API_BASE_URL         = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3001';
 const SWITCH_TIMEOUT_MS    = 3500;
-const POST_SWITCH_DELAY_MS = 2000;
+const POST_SWITCH_DELAY_MS = 2500;
 const MAX_SWITCH_RETRIES   = 3;
-
-const CHASE_CREDIT_CARD_KEYWORDS = [
-  'sapphire', 'freedom', 'flex', 'slate', 'ink', 'visa', 'united', 'marriott',
-  'hyatt', 'southwest', 'amazon', 'prime', 'disney', 'starbucks', 'ihg',
-  'british', 'aeroplan', 'reserve', 'preferred', 'unlimited', 'plus',
-];
-
-const DETECT_CARDS_JS = `
-  (function() {
-    try {
-      var KEYWORDS = ${JSON.stringify(CHASE_CREDIT_CARD_KEYWORDS)};
-      var sel = document.querySelector('mds-select[id="select-credit-card-account"]');
-      if (sel) {
-        var opts = sel.querySelectorAll('mds-select-option');
-        var cards = [];
-        opts.forEach(function(opt, i) {
-          var rawLabel = opt.getAttribute('label') || '';
-          var lowerLabel = rawLabel.toLowerCase();
-          var isCreditCard = KEYWORDS.some(function(k) { return lowerLabel.indexOf(k) !== -1; });
-          if (!isCreditCard) return;
-          var value = opt.getAttribute('value') || String(i);
-          cards.push({ label: rawLabel, value: value, index: i });
-        });
-        var selectedOpt = sel.querySelector('mds-select-option[selected="true"]');
-        var selectedLabel = selectedOpt ? (selectedOpt.getAttribute('label') || '') : '';
-        window.ReactNativeWebView.postMessage(JSON.stringify({
-          type: 'CARDS_DETECTED',
-          cards: cards,
-          selectedLabel: selectedLabel,
-        }));
-        return;
-      }
-      window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'CARDS_DETECTED', cards: [], selectedLabel: null }));
-    } catch(e) {
-      window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'CARDS_DETECTED', cards: [], selectedLabel: null, error: e.message }));
-    }
-  })();
-  true;
-`;
-
-const buildSwitchCardJs = (index, timeoutMs) => `
-  (function() {
-    try {
-      var sel = document.querySelector('mds-select[id="select-credit-card-account"]');
-      if (!sel) {
-        window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'CARD_SWITCH_ERROR', message: 'Dropdown not found' }));
-        return;
-      }
-      var opts = sel.querySelectorAll('mds-select-option');
-      var target = opts[${index}];
-      if (!target) {
-        window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'CARD_SWITCH_ERROR', message: 'Card index out of range' }));
-        return;
-      }
-      target.click();
-      sel.dispatchEvent(new Event('change', { bubbles: true }));
-      setTimeout(function() {
-        var updated = sel.querySelector('mds-select-option[selected="true"]');
-        var label = updated ? (updated.getAttribute('label') || '') : '';
-        window.ReactNativeWebView.postMessage(JSON.stringify({
-          type: 'CARD_SWITCHED',
-          cardLabel: label,
-          expectedIndex: ${index},
-        }));
-      }, ${timeoutMs || SWITCH_TIMEOUT_MS});
-    } catch(e) {
-      window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'CARD_SWITCH_ERROR', message: e.message }));
-    }
-  })();
-  true;
-`;
-
-const buildCaptureJs = (gridSelector) => `
-  (function() {
-    try {
-      var html = null;
-      var MAX = 200000;
-      ${gridSelector ? `
-      var grid = document.querySelector('${gridSelector}');
-      if (grid && grid.innerHTML.length > 500) { html = grid.outerHTML; }
-      ` : ''}
-      if (!html) {
-        var selectors = ['[data-testid*="offer"]','[class*="offers"]','[id*="offers"]','main','[role="main"]'];
-        for (var i = 0; i < selectors.length; i++) {
-          var el = document.querySelector(selectors[i]);
-          if (el && el.innerHTML.length > 500) { html = el.outerHTML; break; }
-        }
-      }
-      if (!html) html = document.documentElement.outerHTML;
-      if (html.length > MAX) html = html.substring(0, MAX);
-      var cardLabel = '';
-      var cardSel = document.querySelector('mds-select[id="select-credit-card-account"]');
-      if (cardSel) {
-        var cardOpt = cardSel.querySelector('mds-select-option[selected="true"]');
-        if (cardOpt) cardLabel = cardOpt.getAttribute('label') || '';
-      }
-      window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'CAPTURE_HTML', html: html, cardLabel: cardLabel }));
-    } catch(e) {
-      window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'ERROR', message: e.message }));
-    }
-  })();
-  true;
-`;
-
-const parseCardLabel = (label) => {
-  if (!label) return { cardName: null, cardLast4: null };
-  const match = label.match(/^(.+?)\s*\(\.\.\.([\w\d]+)\)\s*$/);
-  if (match) return { cardName: match[1].trim(), cardLast4: match[2] };
-  return { cardName: label.trim(), cardLast4: null };
-};
 
 export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
   const webViewRef = useRef(null);
 
-  const cardOptionsRef     = useRef([]);
-  const cardIndexRef       = useRef(0);
-  const syncedCardsRef     = useRef([]);
-  const cardsDiscovered    = useRef(false);
-  const switchRetriesRef   = useRef(0);
-  const syncedCountRef     = useRef(0);
-  const captureArmed       = useRef(false);
-  const autoCapturing      = useRef(false);
+  const cardOptionsRef   = useRef([]);
+  const cardIndexRef     = useRef(0);
+  const syncedCardsRef   = useRef([]);
+  const cardsDiscovered  = useRef(false);
+  const switchRetriesRef = useRef(0);
+  const syncedCountRef   = useRef(0);
+  const captureArmed     = useRef(false);
+  const autoCapturing    = useRef(false);
 
   const [syncing, setSyncing]           = useState(false);
   const [switching, setSwitching]       = useState(false);
@@ -207,19 +83,32 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
     if (!navState.url) return;
     setCurrentUrl(navState.url);
     setPageLoaded(false);
-    setOnOffersPage(false); // reset on every navigation
-    if (!config.useCardsDetectedAsOffersSignal) {
+    setOnOffersPage(false);
+    // URL-based detection for non-SPA banks (neither Chase nor Amex flag)
+    if (!config.useCardsDetectedAsOffersSignal && !config.useAmexCardSwitcher) {
       const url = navState.url.toLowerCase();
-      const onLogin  = (config.loginPaths  || []).some((p) => url.includes(p.toLowerCase()));
-      const onOffers = !onLogin && (config.offersPaths || []).some((p) => url.includes(p.toLowerCase()));
+      const onLogin  = (config.loginPaths  || []).some(p => url.includes(p.toLowerCase()));
+      const onOffers = !onLogin && (config.offersPaths || []).some(p => url.includes(p.toLowerCase()));
       setOnOffersPage(onOffers);
     }
   };
 
-  const handleLoadEnd = () => {
+  const handleLoadEnd = (syntheticEvent) => {
+    const url = (syntheticEvent?.nativeEvent?.url || currentUrl).toLowerCase();
     setPageLoaded(true);
+
     if (bank === 'chase') {
       webViewRef.current?.injectJavaScript(DETECT_CARDS_JS);
+      return;
+    }
+
+    if (bank === 'amex') {
+      const onLogin  = (config.loginPaths  || []).some(p => url.includes(p.toLowerCase()));
+      const onOffers = !onLogin && (config.offersPaths || []).some(p => url.includes(p.toLowerCase()));
+      setOnOffersPage(onOffers);
+      if (onOffers && !cardsDiscovered.current) {
+        webViewRef.current?.injectJavaScript(AMEX_OPEN_AND_DETECT_JS);
+      }
     }
   };
 
@@ -238,8 +127,9 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
     try {
       const data = JSON.parse(event.nativeEvent.data);
 
+      // ── Chase card detection ──────────────────────────────────
       if (data.type === 'CARDS_DETECTED') {
-        const hasCards = data.cards && data.cards.length > 0;
+        const hasCards = data.cards?.length > 0;
         if (!cardsDiscovered.current && hasCards) {
           cardOptionsRef.current  = data.cards;
           cardsDiscovered.current = true;
@@ -249,35 +139,55 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
           setCardIndexUi(cardIndexRef.current);
         }
         setCurrentCard(data.selectedLabel || null);
-        if (config.useCardsDetectedAsOffersSignal) {
-          // Chase: card dropdown present = confirmed on offers page
-          // This fires before onLoadEnd so we don't gate on pageLoaded here
-          setOnOffersPage(hasCards);
+        if (config.useCardsDetectedAsOffersSignal) setOnOffersPage(hasCards);
+        return;
+      }
+
+      // ── Amex card detection ───────────────────────────────────
+      if (data.type === 'AMEX_CARDS_DETECTED') {
+        const hasCards = data.cards?.length > 0;
+        if (!cardsDiscovered.current && hasCards) {
+          cardOptionsRef.current  = data.cards;
+          cardsDiscovered.current = true;
+          setCardCount(data.cards.length);
+          const activeIdx = data.cards.findIndex(c => c.selected);
+          cardIndexRef.current = activeIdx >= 0 ? activeIdx : 0;
+          setCardIndexUi(cardIndexRef.current);
+          setCurrentCard(data.selectedLabel || null);
         }
         return;
       }
 
+      // ── Card switched (Chase + Amex) ──────────────────────────
       if (data.type === 'CARD_SWITCHED') {
-        const expectedIndex = data.expectedIndex;
-        const expectedLabel = cardOptionsRef.current.find(c => c.index === expectedIndex)?.label || '';
-        const actualLabel   = data.cardLabel || '';
-        const switchConfirmed = expectedLabel
-          ? actualLabel.trim() === expectedLabel.trim()
-          : !!actualLabel;
+        let switchConfirmed = false;
+        if (bank === 'amex') {
+          switchConfirmed = !!data.cardLabel;
+        } else {
+          const expectedLabel = cardOptionsRef.current.find(c => c.index === data.expectedIndex)?.label || '';
+          switchConfirmed = expectedLabel
+            ? data.cardLabel?.trim() === expectedLabel.trim()
+            : !!data.cardLabel;
+        }
 
         if (!switchConfirmed && switchRetriesRef.current < MAX_SWITCH_RETRIES) {
           switchRetriesRef.current += 1;
-          const retryDelay = SWITCH_TIMEOUT_MS + (switchRetriesRef.current * 1500);
-          webViewRef.current?.injectJavaScript(buildSwitchCardJs(expectedIndex, retryDelay));
+          const retryDelay = SWITCH_TIMEOUT_MS + switchRetriesRef.current * 1500;
+          if (bank === 'amex') {
+            const card = cardOptionsRef.current[cardIndexRef.current];
+            webViewRef.current?.injectJavaScript(buildAmexSwitchCardJs(card.testId, retryDelay));
+          } else {
+            webViewRef.current?.injectJavaScript(buildSwitchCardJs(data.expectedIndex, retryDelay));
+          }
           return;
         }
 
         switchRetriesRef.current = 0;
         setSwitching(false);
-        setCurrentCard(actualLabel || expectedLabel || null);
+        setCurrentCard(data.cardLabel || null);
         autoCapturing.current = true;
         setTimeout(() => {
-          captureArmed.current = true;
+          captureArmed.current  = true;
           autoCapturing.current = false;
           webViewRef.current?.injectJavaScript(buildCaptureJs(config.gridSelector));
         }, POST_SWITCH_DELAY_MS);
@@ -297,12 +207,10 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         return;
       }
 
-      if (data.type !== 'CAPTURE_HTML') return;
-      if (!captureArmed.current) return;
+      if (data.type !== 'CAPTURE_HTML' || !captureArmed.current) return;
       captureArmed.current = false;
 
       setSyncing(true);
-
       const user = getAuthInstance().currentUser;
       if (!user) throw new Error('You must be signed in to sync offers.');
       const token = await user.getIdToken();
@@ -317,7 +225,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
         body: JSON.stringify({ html: data.html, bank, cardName: fullCardName }),
       });
-
       const result = await response.json();
       if (!response.ok) throw new Error(result.error || 'Sync failed');
 
@@ -325,10 +232,9 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         ...syncedCardsRef.current,
         { cardName: fullCardName || 'Unknown Card', count: result.synced ?? 0 },
       ];
-
       syncedCountRef.current += 1;
-      const totalCards = cardOptionsRef.current.length;
 
+      const totalCards = cardOptionsRef.current.length;
       setSyncing(false);
 
       if (syncedCountRef.current < totalCards) {
@@ -337,15 +243,19 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         setCardIndexUi(nextPos);
         setSwitching(true);
         switchRetriesRef.current = 0;
-        const domIndex = cardOptionsRef.current[nextPos].index;
-        webViewRef.current?.injectJavaScript(buildSwitchCardJs(domIndex, SWITCH_TIMEOUT_MS));
+        if (bank === 'amex') {
+          const nextCard = cardOptionsRef.current[nextPos];
+          webViewRef.current?.injectJavaScript(buildAmexSwitchCardJs(nextCard.testId, SWITCH_TIMEOUT_MS));
+        } else {
+          webViewRef.current?.injectJavaScript(buildSwitchCardJs(cardOptionsRef.current[nextPos].index, SWITCH_TIMEOUT_MS));
+        }
       } else {
         const total = syncedCardsRef.current.reduce((sum, c) => sum + c.count, 0);
         onSuccess(total, syncedCardsRef.current);
         onClose();
       }
     } catch (err) {
-      captureArmed.current = false;
+      captureArmed.current  = false;
       autoCapturing.current = false;
       setSyncing(false);
       setSwitching(false);
@@ -354,9 +264,8 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
   };
 
   const { cardName } = parseCardLabel(currentCard);
-  const totalCards = cardCount || 1;
-
-  const statusText = switching
+  const totalCards   = cardCount || 1;
+  const statusText   = switching
     ? `⏳ Switching to card ${cardIndexUi + 1} of ${totalCards}...`
     : syncing
       ? `🔄 Syncing ${cardName || 'card'} (${cardIndexUi + 1} of ${totalCards})...`
@@ -371,8 +280,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         </View>
       );
     }
-    // Show Sync button as soon as we know we're on the offers page
-    // (for Chase this happens via CARDS_DETECTED, before onLoadEnd)
     if (onOffersPage) {
       return (
         <TouchableOpacity style={s.syncBtn} onPress={handleSyncPress}>
@@ -380,7 +287,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         </TouchableOpacity>
       );
     }
-    // Don't show the fallback button until the page has actually loaded
     if (!pageLoaded) return null;
     return (
       <>
@@ -425,20 +331,20 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
 }
 
 const s = StyleSheet.create({
-  overlay:      { flex: 1, justifyContent: 'flex-end', backgroundColor: 'rgba(0,0,0,0.45)' },
-  sheet:        { height: '87%', backgroundColor: 'white', borderTopLeftRadius: 20, borderTopRightRadius: 20, overflow: 'hidden' },
-  handle:       { width: 40, height: 4, backgroundColor: colors.border, borderRadius: radii.full, alignSelf: 'center', marginTop: 10, marginBottom: 4 },
-  header:       { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', paddingHorizontal: 16, paddingVertical: 12, borderBottomWidth: 1, borderBottomColor: colors.border },
-  closeBtn:     { width: 36, height: 36, borderRadius: 18, backgroundColor: colors.disabledBg, alignItems: 'center', justifyContent: 'center' },
-  closeBtnText: { fontSize: 14, color: colors.textSecondary, fontWeight: '600' },
-  headerTitle:  { fontSize: 16, fontWeight: '700', color: colors.textPrimary },
-  webview:      { flex: 1 },
-  footer:       { minHeight: 56, padding: 16, borderTopWidth: 1, borderTopColor: colors.border, backgroundColor: 'white' },
-  hint:         { fontSize: 12, color: colors.textMuted, textAlign: 'center', marginBottom: 10 },
-  syncBtn:      { backgroundColor: colors.primary, borderRadius: radii.md, paddingVertical: 14, alignItems: 'center' },
-  goToOffersBtn:{ backgroundColor: colors.primaryLight, borderRadius: radii.md, paddingVertical: 14, alignItems: 'center' },
-  syncBtnText:  { color: 'white', fontSize: 16, fontWeight: '700' },
-  statusRow:    { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', paddingVertical: 10 },
-  spinner:      { marginRight: 10 },
-  statusText:   { fontSize: 14, fontWeight: '600', color: colors.textPrimary },
+  overlay:       { flex: 1, justifyContent: 'flex-end', backgroundColor: 'rgba(0,0,0,0.45)' },
+  sheet:         { height: '87%', backgroundColor: 'white', borderTopLeftRadius: 20, borderTopRightRadius: 20, overflow: 'hidden' },
+  handle:        { width: 40, height: 4, backgroundColor: colors.border, borderRadius: radii.full, alignSelf: 'center', marginTop: 10, marginBottom: 4 },
+  header:        { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', paddingHorizontal: 16, paddingVertical: 12, borderBottomWidth: 1, borderBottomColor: colors.border },
+  closeBtn:      { width: 36, height: 36, borderRadius: 18, backgroundColor: colors.disabledBg, alignItems: 'center', justifyContent: 'center' },
+  closeBtnText:  { fontSize: 14, color: colors.textSecondary, fontWeight: '600' },
+  headerTitle:   { fontSize: 16, fontWeight: '700', color: colors.textPrimary },
+  webview:       { flex: 1 },
+  footer:        { minHeight: 56, padding: 16, borderTopWidth: 1, borderTopColor: colors.border, backgroundColor: 'white' },
+  hint:          { fontSize: 12, color: colors.textMuted, textAlign: 'center', marginBottom: 10 },
+  syncBtn:       { backgroundColor: colors.primary, borderRadius: radii.md, paddingVertical: 14, alignItems: 'center' },
+  goToOffersBtn: { backgroundColor: colors.primaryLight, borderRadius: radii.md, paddingVertical: 14, alignItems: 'center' },
+  syncBtnText:   { color: 'white', fontSize: 16, fontWeight: '700' },
+  statusRow:     { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', paddingVertical: 10 },
+  spinner:       { marginRight: 10 },
+  statusText:    { fontSize: 14, fontWeight: '600', color: colors.textPrimary },
 });

--- a/mobile/components/SyncWebView.js
+++ b/mobile/components/SyncWebView.js
@@ -9,6 +9,13 @@
 //   2. Page loaded, not on offers page → "Go to Offers Page"
 //   3. Sync in progress  → spinner + status
 //
+// onOffersPage source of truth per bank:
+//   Chase → CARDS_DETECTED message (SPA)
+//   Amex  → handleLoadEnd URL check
+//          navState fires AFTER loadEnd on Amex and would reset
+//          onOffersPage back to false — so we skip the reset for Amex only
+//   Other → handleNavigationStateChange URL check
+//
 // Adding a new bank:
 //   1. Add entry to sync/bankConfig.js
 //   2. Create sync/<bank>Sync.js with detect + switch JS
@@ -23,10 +30,10 @@ import { WebView } from 'react-native-webview';
 import { getAuthInstance } from '../lib/firebaseClient.js';
 import { colors, radii } from '../shared/theme.js';
 
-import { BANK_CONFIG }             from './sync/bankConfig.js';
-import { DETECT_CARDS_JS, buildSwitchCardJs } from './sync/chaseSync.js';
+import { BANK_CONFIG }                                    from './sync/bankConfig.js';
+import { DETECT_CARDS_JS, buildSwitchCardJs }             from './sync/chaseSync.js';
 import { AMEX_OPEN_AND_DETECT_JS, buildAmexSwitchCardJs } from './sync/amexSync.js';
-import { buildCaptureJs, parseCardLabel } from './sync/captureJs.js';
+import { buildCaptureJs, parseCardLabel }                 from './sync/captureJs.js';
 
 const API_BASE_URL         = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3001';
 const SWITCH_TIMEOUT_MS    = 3500;
@@ -83,10 +90,18 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
     if (!navState.url) return;
     setCurrentUrl(navState.url);
     setPageLoaded(false);
+
+    // Amex: handleLoadEnd is the source of truth for onOffersPage.
+    // navState fires AFTER loadEnd on Amex — resetting here would clobber
+    // the value already set correctly by handleLoadEnd.
+    if (config.useAmexCardSwitcher) return;
+
+    // Chase: CARDS_DETECTED message is source of truth — reset is fine here
+    // because CARDS_DETECTED will fire again and restore onOffersPage=true.
+    // Other banks: URL-based detection handled here.
     setOnOffersPage(false);
-    // URL-based detection for non-SPA banks (neither Chase nor Amex flag)
-    if (!config.useCardsDetectedAsOffersSignal && !config.useAmexCardSwitcher) {
-      const url = navState.url.toLowerCase();
+    if (!config.useCardsDetectedAsOffersSignal) {
+      const url      = navState.url.toLowerCase();
       const onLogin  = (config.loginPaths  || []).some(p => url.includes(p.toLowerCase()));
       const onOffers = !onLogin && (config.offersPaths || []).some(p => url.includes(p.toLowerCase()));
       setOnOffersPage(onOffers);

--- a/mobile/components/SyncWebView.js
+++ b/mobile/components/SyncWebView.js
@@ -88,17 +88,13 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
 
   const handleNavigationStateChange = (navState) => {
     if (!navState.url) return;
+    console.log(`[SyncWebView:${bank}] navState url:`, navState.url);
     setCurrentUrl(navState.url);
     setPageLoaded(false);
 
     // Amex: handleLoadEnd is the source of truth for onOffersPage.
-    // navState fires AFTER loadEnd on Amex — resetting here would clobber
-    // the value already set correctly by handleLoadEnd.
     if (config.useAmexCardSwitcher) return;
 
-    // Chase: CARDS_DETECTED message is source of truth — reset is fine here
-    // because CARDS_DETECTED will fire again and restore onOffersPage=true.
-    // Other banks: URL-based detection handled here.
     setOnOffersPage(false);
     if (!config.useCardsDetectedAsOffersSignal) {
       const url      = navState.url.toLowerCase();
@@ -110,6 +106,7 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
 
   const handleLoadEnd = (syntheticEvent) => {
     const url = (syntheticEvent?.nativeEvent?.url || currentUrl).toLowerCase();
+    console.log(`[SyncWebView:${bank}] loadEnd url:`, url);
     setPageLoaded(true);
 
     if (bank === 'chase') {
@@ -120,8 +117,10 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
     if (bank === 'amex') {
       const onLogin  = (config.loginPaths  || []).some(p => url.includes(p.toLowerCase()));
       const onOffers = !onLogin && (config.offersPaths || []).some(p => url.includes(p.toLowerCase()));
+      console.log(`[SyncWebView:amex] onLogin=${onLogin} onOffers=${onOffers} cardsDiscovered=${cardsDiscovered.current}`);
       setOnOffersPage(onOffers);
       if (onOffers && !cardsDiscovered.current) {
+        console.log('[SyncWebView:amex] injecting AMEX_OPEN_AND_DETECT_JS');
         webViewRef.current?.injectJavaScript(AMEX_OPEN_AND_DETECT_JS);
       }
     }
@@ -129,20 +128,23 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
 
   const handleGoToOffers = () => {
     const target = config.offersUrl || config.url;
+    console.log(`[SyncWebView:${bank}] navigating to offersUrl:`, target);
     webViewRef.current?.injectJavaScript(`window.location.replace('${target}'); true;`);
   };
 
   const handleSyncPress = () => {
+    console.log(`[SyncWebView:${bank}] Sync pressed — gridSelector:`, config.gridSelector, 'captureMaxBytes:', config.captureMaxBytes);
     setSyncStarted(true);
     captureArmed.current = true;
-    webViewRef.current?.injectJavaScript(buildCaptureJs(config.gridSelector));
+    webViewRef.current?.injectJavaScript(buildCaptureJs(config.gridSelector, config.captureMaxBytes));
   };
 
   const handleMessage = async (event) => {
     try {
       const data = JSON.parse(event.nativeEvent.data);
+      console.log(`[SyncWebView:${bank}] message type:`, data.type, data.error || '');
 
-      // ── Chase card detection ──────────────────────────────────
+      // ── Chase card detection ────────────────────────────
       if (data.type === 'CARDS_DETECTED') {
         const hasCards = data.cards?.length > 0;
         if (!cardsDiscovered.current && hasCards) {
@@ -158,8 +160,9 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         return;
       }
 
-      // ── Amex card detection ───────────────────────────────────
+      // ── Amex card detection ────────────────────────────
       if (data.type === 'AMEX_CARDS_DETECTED') {
+        console.log('[SyncWebView:amex] AMEX_CARDS_DETECTED cards:', data.cards?.length, 'error:', data.error);
         const hasCards = data.cards?.length > 0;
         if (!cardsDiscovered.current && hasCards) {
           cardOptionsRef.current  = data.cards;
@@ -173,7 +176,7 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         return;
       }
 
-      // ── Card switched (Chase + Amex) ──────────────────────────
+      // ── Card switched (Chase + Amex) ──────────────────────
       if (data.type === 'CARD_SWITCHED') {
         let switchConfirmed = false;
         if (bank === 'amex') {
@@ -204,7 +207,7 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         setTimeout(() => {
           captureArmed.current  = true;
           autoCapturing.current = false;
-          webViewRef.current?.injectJavaScript(buildCaptureJs(config.gridSelector));
+          webViewRef.current?.injectJavaScript(buildCaptureJs(config.gridSelector, config.captureMaxBytes));
         }, POST_SWITCH_DELAY_MS);
         return;
       }
@@ -222,8 +225,13 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         return;
       }
 
-      if (data.type !== 'CAPTURE_HTML' || !captureArmed.current) return;
+      if (data.type !== 'CAPTURE_HTML' || !captureArmed.current) {
+        console.log(`[SyncWebView:${bank}] ignoring message — type=${data.type} captureArmed=${captureArmed.current}`);
+        return;
+      }
       captureArmed.current = false;
+
+      console.log(`[SyncWebView:${bank}] CAPTURE_HTML received — html.length=${data.html?.length} cardLabel=${data.cardLabel}`);
 
       setSyncing(true);
       const user = getAuthInstance().currentUser;
@@ -235,12 +243,15 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         ? (cardLast4 ? `${cardName} (...${cardLast4})` : cardName)
         : null;
 
+      console.log(`[SyncWebView:${bank}] POSTing to ${API_BASE_URL}/api/offers/parse — bank=${bank} cardName=${fullCardName}`);
+
       const response = await fetch(`${API_BASE_URL}/api/offers/parse`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
         body: JSON.stringify({ html: data.html, bank, cardName: fullCardName }),
       });
       const result = await response.json();
+      console.log(`[SyncWebView:${bank}] API response:`, JSON.stringify(result));
       if (!response.ok) throw new Error(result.error || 'Sync failed');
 
       syncedCardsRef.current = [
@@ -274,6 +285,7 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       autoCapturing.current = false;
       setSyncing(false);
       setSwitching(false);
+      console.error(`[SyncWebView:${bank}] handleMessage error:`, err.message);
       Alert.alert('Sync Failed', err.message);
     }
   };

--- a/mobile/components/sync/amexSync.js
+++ b/mobile/components/sync/amexSync.js
@@ -1,0 +1,111 @@
+// ─────────────────────────────────────────────
+// AMEX SYNC — JS injection strings
+// Amex uses a combobox + listbox pattern:
+//   [data-testid="simple_switcher_combobox"]
+//   [role="option"][data-testid*="CARD_PRODUCT"]
+//
+// Card switching:
+//   1. Click combobox to open listbox
+//   2. Click the target option by data-testid
+//   3. Wait for re-render, then confirm via display label
+//
+// CARD_PRODUCT filter excludes checking/savings accounts.
+// ─────────────────────────────────────────────
+
+const DETECT_CARDS_INNER = `
+  (function detectAmexCards() {
+    var options = document.querySelectorAll('[role="option"][data-testid*="CARD_PRODUCT"]');
+    var cards = [];
+    options.forEach(function(opt, i) {
+      var nameEl  = opt.querySelector('[data-testid="simple_switcher_display_name"]');
+      var numEl   = opt.querySelector('[data-testid="simple_switcher_display_number_val"]');
+      var name    = nameEl ? nameEl.innerText.trim() : '';
+      var numRaw  = numEl  ? numEl.innerText.trim()  : '';
+      var last4   = numRaw.replace(/[^\\d]/g, '').slice(-4);
+      var selected = opt.getAttribute('aria-selected') === 'true';
+      var testId  = opt.getAttribute('data-testid') || '';
+      cards.push({ label: name, last4: last4, testId: testId, index: i, selected: selected });
+    });
+    var selectedCard = cards.find(function(c) { return c.selected; });
+    window.ReactNativeWebView.postMessage(JSON.stringify({
+      type: 'AMEX_CARDS_DETECTED',
+      cards: cards,
+      selectedLabel: selectedCard ? selectedCard.label + ' (...' + selectedCard.last4 + ')' : '',
+    }));
+  })()
+`;
+
+export const AMEX_OPEN_AND_DETECT_JS = `
+  (function() {
+    try {
+      var combobox = document.querySelector('[data-testid="simple_switcher_combobox"]');
+      if (!combobox) {
+        window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'AMEX_CARDS_DETECTED', cards: [], selectedLabel: '', error: 'Combobox not found' }));
+        return;
+      }
+      var alreadyOpen = combobox.getAttribute('aria-expanded') === 'true';
+      if (alreadyOpen) {
+        ${DETECT_CARDS_INNER}
+        return;
+      }
+      combobox.click();
+      setTimeout(function() {
+        ${DETECT_CARDS_INNER}
+      }, 600);
+    } catch(e) {
+      window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'AMEX_CARDS_DETECTED', cards: [], selectedLabel: '', error: e.message }));
+    }
+  })();
+  true;
+`;
+
+export const buildAmexSwitchCardJs = (testId, timeoutMs = 3500) => `
+  (function() {
+    try {
+      var combobox = document.querySelector('[data-testid="simple_switcher_combobox"]');
+      if (!combobox) {
+        window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'CARD_SWITCH_ERROR', message: 'Amex combobox not found' }));
+        return;
+      }
+      combobox.click();
+      setTimeout(function() {
+        var option = document.querySelector('[data-testid="${testId}"]');
+        if (!option) {
+          window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'CARD_SWITCH_ERROR', message: 'Amex option not found: ${testId}' }));
+          return;
+        }
+        option.click();
+        setTimeout(function() {
+          var displayEl = document.querySelector('[data-testid="simple_switcher_selected_option_display"]');
+          var nameEl    = displayEl ? displayEl.querySelector('[data-testid="simple_switcher_display_name"]') : null;
+          var numEl     = displayEl ? displayEl.querySelector('[data-testid="simple_switcher_display_number_val"]') : null;
+          var name      = nameEl ? nameEl.innerText.trim() : '';
+          var numRaw    = numEl  ? numEl.innerText.trim()  : '';
+          var last4     = numRaw.replace(/[^\\d]/g, '').slice(-4);
+          var cardLabel = name + (last4 ? ' (...' + last4 + ')' : '');
+          window.ReactNativeWebView.postMessage(JSON.stringify({
+            type: 'CARD_SWITCHED',
+            cardLabel: cardLabel,
+            expectedTestId: '${testId}',
+          }));
+        }, ${timeoutMs});
+      }, 600);
+    } catch(e) {
+      window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'CARD_SWITCH_ERROR', message: e.message }));
+    }
+  })();
+  true;
+`;
+
+// Read current card label from Amex combobox display
+export const AMEX_READ_CARD_LABEL_JS = `
+  (function() {
+    var displayEl = document.querySelector('[data-testid="simple_switcher_selected_option_display"]');
+    var nameEl    = displayEl ? displayEl.querySelector('[data-testid="simple_switcher_display_name"]') : null;
+    var numEl     = displayEl ? displayEl.querySelector('[data-testid="simple_switcher_display_number_val"]') : null;
+    var name      = nameEl ? nameEl.innerText.trim() : '';
+    var numRaw    = numEl  ? numEl.innerText.trim()  : '';
+    var last4     = numRaw.replace(/[^\\d]/g, '').slice(-4);
+    return name + (last4 ? ' (...' + last4 + ')' : '');
+  })()
+`;

--- a/mobile/components/sync/bankConfig.js
+++ b/mobile/components/sync/bankConfig.js
@@ -1,0 +1,38 @@
+// ─────────────────────────────────────────────
+// BANK CONFIG
+// Add a new entry here to support a new bank.
+//
+// useCardsDetectedAsOffersSignal: true
+//   → Chase-style SPA. Use JS CARDS_DETECTED message
+//     to know we're on the offers page (not URL).
+//
+// useAmexCardSwitcher: true
+//   → Amex-style combobox. Use AMEX_CARDS_DETECTED
+//     and buildAmexSwitchCardJs to switch cards.
+//
+// Neither flag (default)
+//   → URL-based offers detection (future banks).
+// ─────────────────────────────────────────────
+
+export const BANK_CONFIG = {
+  chase: {
+    url: 'https://secure.chase.com/web/auth/dashboard#/dashboard/merchantOffers/offer-hub',
+    offersUrl: 'https://secure.chase.com/web/auth/dashboard#/dashboard/merchantOffers/offer-hub',
+    label: 'Chase Offers',
+    color: '#1a3a6b',
+    offersPaths: ['/cardmember-offers', 'merchantOffers'],
+    loginPaths: ['/sign-in', '/logon', '/login', '/sso', '/identify', '/challenge'],
+    gridSelector: '[data-testid="grid-items-container"]',
+    useCardsDetectedAsOffersSignal: true,
+  },
+  amex: {
+    url: 'https://www.americanexpress.com/en-us/benefits/offers/',
+    offersUrl: 'https://www.americanexpress.com/en-us/benefits/offers/',
+    label: 'Amex Offers',
+    color: '#007ac1',
+    offersPaths: ['/benefits/offers'],
+    loginPaths: ['/login', '/sign-in', '/identity', '/auth', '/challenge'],
+    gridSelector: null,
+    useAmexCardSwitcher: true,
+  },
+};

--- a/mobile/components/sync/bankConfig.js
+++ b/mobile/components/sync/bankConfig.js
@@ -26,12 +26,15 @@ export const BANK_CONFIG = {
     useCardsDetectedAsOffersSignal: true,
   },
   amex: {
+    // Entry URL — redirects to login if not authenticated
     url: 'https://www.americanexpress.com/en-us/benefits/offers/',
-    offersUrl: 'https://www.americanexpress.com/en-us/benefits/offers/',
+    // After login, Amex lands on global.americanexpress.com/offers/enrolled
+    offersUrl: 'https://global.americanexpress.com/offers',
     label: 'Amex Offers',
     color: '#007ac1',
-    offersPaths: ['/benefits/offers'],
-    loginPaths: ['/login', '/sign-in', '/identity', '/auth', '/challenge'],
+    // Actual offers pages on global.americanexpress.com
+    offersPaths: ['/offers/enrolled', '/offers'],
+    loginPaths: ['/account/login', '/login', '/sign-in', '/identity', '/auth', '/challenge'],
     gridSelector: null,
     useAmexCardSwitcher: true,
   },

--- a/mobile/components/sync/bankConfig.js
+++ b/mobile/components/sync/bankConfig.js
@@ -29,14 +29,15 @@ export const BANK_CONFIG = {
   amex: {
     // Entry URL — redirects to login if not authenticated
     url: 'https://www.americanexpress.com/en-us/benefits/offers/',
-    // After login, Amex lands on global.americanexpress.com/offers
+    // After login Amex lands on global.americanexpress.com
     offersUrl: 'https://global.americanexpress.com/offers/eligible',
     label: 'Amex Offers',
     color: '#007ac1',
-    // Actual offers pages on global.americanexpress.com
-    offersPaths: ['/offers/enrolled', '/offers/eligible', '/offers'],
+    // IMPORTANT: must only match global.americanexpress.com/offers* NOT
+    // americanexpress.com/en-us/benefits/offers (marketing page)
+    offersPaths: ['global.americanexpress.com/offers'],
     loginPaths: ['/account/login', '/login', '/sign-in', '/identity', '/auth', '/challenge'],
-    // Amex renders all offer rows inside [data-testid="listViewContainer"]
+    // Real offer rows are direct DIV children of this container
     gridSelector: '[data-testid="listViewContainer"]',
     captureMaxBytes: 500000,
     useAmexCardSwitcher: true,

--- a/mobile/components/sync/bankConfig.js
+++ b/mobile/components/sync/bankConfig.js
@@ -23,19 +23,22 @@ export const BANK_CONFIG = {
     offersPaths: ['/cardmember-offers', 'merchantOffers'],
     loginPaths: ['/sign-in', '/logon', '/login', '/sso', '/identify', '/challenge'],
     gridSelector: '[data-testid="grid-items-container"]',
+    captureMaxBytes: 200000,
     useCardsDetectedAsOffersSignal: true,
   },
   amex: {
     // Entry URL — redirects to login if not authenticated
     url: 'https://www.americanexpress.com/en-us/benefits/offers/',
-    // After login, Amex lands on global.americanexpress.com/offers/enrolled
-    offersUrl: 'https://global.americanexpress.com/offers',
+    // After login, Amex lands on global.americanexpress.com/offers
+    offersUrl: 'https://global.americanexpress.com/offers/eligible',
     label: 'Amex Offers',
     color: '#007ac1',
     // Actual offers pages on global.americanexpress.com
-    offersPaths: ['/offers/enrolled', '/offers'],
+    offersPaths: ['/offers/enrolled', '/offers/eligible', '/offers'],
     loginPaths: ['/account/login', '/login', '/sign-in', '/identity', '/auth', '/challenge'],
-    gridSelector: null,
+    // Amex renders all offer rows inside [data-testid="listViewContainer"]
+    gridSelector: '[data-testid="listViewContainer"]',
+    captureMaxBytes: 500000,
     useAmexCardSwitcher: true,
   },
 };

--- a/mobile/components/sync/captureJs.js
+++ b/mobile/components/sync/captureJs.js
@@ -9,19 +9,42 @@ export const buildCaptureJs = (gridSelector, maxBytes = 200000) => `
     try {
       var html = null;
       var MAX = ${maxBytes || 200000};
+
+      // DEBUG: log what page we are on
+      console.log('[CaptureJS] URL:', window.location.href);
+      console.log('[CaptureJS] gridSelector:', '${gridSelector || "(none)"}');
+
       ${gridSelector ? `
       var grid = document.querySelector('${gridSelector}');
+      console.log('[CaptureJS] grid found:', !!grid, 'innerHTML length:', grid ? grid.innerHTML.length : 0);
       if (grid && grid.innerHTML.length > 500) { html = grid.outerHTML; }
       ` : ''}
+
       if (!html) {
+        console.log('[CaptureJS] gridSelector miss, trying fallbacks...');
         var selectors = ['[data-testid*="offer"]','[class*="offers"]','[id*="offers"]','main','[role="main"]'];
         for (var i = 0; i < selectors.length; i++) {
           var el = document.querySelector(selectors[i]);
-          if (el && el.innerHTML.length > 500) { html = el.outerHTML; break; }
+          if (el && el.innerHTML.length > 500) {
+            console.log('[CaptureJS] fallback matched:', selectors[i], 'length:', el.innerHTML.length);
+            html = el.outerHTML;
+            break;
+          }
         }
       }
-      if (!html) html = document.documentElement.outerHTML;
-      if (html.length > MAX) html = html.substring(0, MAX);
+
+      if (!html) {
+        console.log('[CaptureJS] all fallbacks missed, using documentElement');
+        html = document.documentElement.outerHTML;
+      }
+
+      var truncated = html.length > MAX;
+      if (truncated) html = html.substring(0, MAX);
+      console.log('[CaptureJS] html length:', html.length, 'truncated:', truncated);
+
+      // Count listViewRow elements as a quick sanity check
+      var rowCount = (html.match(/listViewRow/g) || []).length;
+      console.log('[CaptureJS] listViewRow occurrences in captured html:', rowCount);
 
       var cardLabel = '';
 
@@ -34,6 +57,7 @@ export const buildCaptureJs = (gridSelector, maxBytes = 200000) => `
         var numRaw = numEl  ? numEl.innerText.trim()  : '';
         var last4  = numRaw.replace(/[^\\d]/g, '').slice(-4);
         cardLabel  = name + (last4 ? ' (...' + last4 + ')' : '');
+        console.log('[CaptureJS] Amex cardLabel:', cardLabel);
       }
 
       // Chase: read from mds-select
@@ -42,11 +66,14 @@ export const buildCaptureJs = (gridSelector, maxBytes = 200000) => `
         if (chaseSel) {
           var selectedOpt = chaseSel.querySelector('mds-select-option[selected="true"]');
           if (selectedOpt) cardLabel = selectedOpt.getAttribute('label') || '';
+          console.log('[CaptureJS] Chase cardLabel:', cardLabel);
         }
       }
 
       window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'CAPTURE_HTML', html: html, cardLabel: cardLabel }));
+      console.log('[CaptureJS] CAPTURE_HTML posted');
     } catch(e) {
+      console.log('[CaptureJS] ERROR:', e.message);
       window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'ERROR', message: e.message }));
     }
   })();

--- a/mobile/components/sync/captureJs.js
+++ b/mobile/components/sync/captureJs.js
@@ -4,11 +4,11 @@
 // Reads card label from whichever bank is active.
 // ─────────────────────────────────────────────
 
-export const buildCaptureJs = (gridSelector) => `
+export const buildCaptureJs = (gridSelector, maxBytes = 200000) => `
   (function() {
     try {
       var html = null;
-      var MAX = 200000;
+      var MAX = ${maxBytes || 200000};
       ${gridSelector ? `
       var grid = document.querySelector('${gridSelector}');
       if (grid && grid.innerHTML.length > 500) { html = grid.outerHTML; }

--- a/mobile/components/sync/captureJs.js
+++ b/mobile/components/sync/captureJs.js
@@ -1,0 +1,61 @@
+// ─────────────────────────────────────────────
+// CAPTURE JS — shared offer HTML capture
+// Works for both Chase and Amex.
+// Reads card label from whichever bank is active.
+// ─────────────────────────────────────────────
+
+export const buildCaptureJs = (gridSelector) => `
+  (function() {
+    try {
+      var html = null;
+      var MAX = 200000;
+      ${gridSelector ? `
+      var grid = document.querySelector('${gridSelector}');
+      if (grid && grid.innerHTML.length > 500) { html = grid.outerHTML; }
+      ` : ''}
+      if (!html) {
+        var selectors = ['[data-testid*="offer"]','[class*="offers"]','[id*="offers"]','main','[role="main"]'];
+        for (var i = 0; i < selectors.length; i++) {
+          var el = document.querySelector(selectors[i]);
+          if (el && el.innerHTML.length > 500) { html = el.outerHTML; break; }
+        }
+      }
+      if (!html) html = document.documentElement.outerHTML;
+      if (html.length > MAX) html = html.substring(0, MAX);
+
+      var cardLabel = '';
+
+      // Amex: read from combobox display
+      var amexDisplay = document.querySelector('[data-testid="simple_switcher_selected_option_display"]');
+      if (amexDisplay) {
+        var nameEl = amexDisplay.querySelector('[data-testid="simple_switcher_display_name"]');
+        var numEl  = amexDisplay.querySelector('[data-testid="simple_switcher_display_number_val"]');
+        var name   = nameEl ? nameEl.innerText.trim() : '';
+        var numRaw = numEl  ? numEl.innerText.trim()  : '';
+        var last4  = numRaw.replace(/[^\\d]/g, '').slice(-4);
+        cardLabel  = name + (last4 ? ' (...' + last4 + ')' : '');
+      }
+
+      // Chase: read from mds-select
+      if (!cardLabel) {
+        var chaseSel = document.querySelector('mds-select[id="select-credit-card-account"]');
+        if (chaseSel) {
+          var selectedOpt = chaseSel.querySelector('mds-select-option[selected="true"]');
+          if (selectedOpt) cardLabel = selectedOpt.getAttribute('label') || '';
+        }
+      }
+
+      window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'CAPTURE_HTML', html: html, cardLabel: cardLabel }));
+    } catch(e) {
+      window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'ERROR', message: e.message }));
+    }
+  })();
+  true;
+`;
+
+export const parseCardLabel = (label) => {
+  if (!label) return { cardName: null, cardLast4: null };
+  const match = label.match(/^(.+?)\s*\(\.\.\.([\w\d]+)\)\s*$/);
+  if (match) return { cardName: match[1].trim(), cardLast4: match[2] };
+  return { cardName: label.trim(), cardLast4: null };
+};

--- a/mobile/components/sync/chaseSync.js
+++ b/mobile/components/sync/chaseSync.js
@@ -1,0 +1,77 @@
+// ─────────────────────────────────────────────
+// CHASE SYNC — JS injection strings
+// Chase uses a custom web component dropdown:
+//   mds-select[id="select-credit-card-account"]
+// CARDS_DETECTED fires before onLoadEnd (SPA).
+// ─────────────────────────────────────────────
+
+export const CHASE_CREDIT_CARD_KEYWORDS = [
+  'sapphire', 'freedom', 'flex', 'slate', 'ink', 'visa', 'united', 'marriott',
+  'hyatt', 'southwest', 'amazon', 'prime', 'disney', 'starbucks', 'ihg',
+  'british', 'aeroplan', 'reserve', 'preferred', 'unlimited', 'plus',
+];
+
+export const DETECT_CARDS_JS = `
+  (function() {
+    try {
+      var KEYWORDS = ${JSON.stringify(CHASE_CREDIT_CARD_KEYWORDS)};
+      var sel = document.querySelector('mds-select[id="select-credit-card-account"]');
+      if (sel) {
+        var opts = sel.querySelectorAll('mds-select-option');
+        var cards = [];
+        opts.forEach(function(opt, i) {
+          var rawLabel = opt.getAttribute('label') || '';
+          var lowerLabel = rawLabel.toLowerCase();
+          var isCreditCard = KEYWORDS.some(function(k) { return lowerLabel.indexOf(k) !== -1; });
+          if (!isCreditCard) return;
+          var value = opt.getAttribute('value') || String(i);
+          cards.push({ label: rawLabel, value: value, index: i });
+        });
+        var selectedOpt = sel.querySelector('mds-select-option[selected="true"]');
+        var selectedLabel = selectedOpt ? (selectedOpt.getAttribute('label') || '') : '';
+        window.ReactNativeWebView.postMessage(JSON.stringify({
+          type: 'CARDS_DETECTED',
+          cards: cards,
+          selectedLabel: selectedLabel,
+        }));
+        return;
+      }
+      window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'CARDS_DETECTED', cards: [], selectedLabel: null }));
+    } catch(e) {
+      window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'CARDS_DETECTED', cards: [], selectedLabel: null, error: e.message }));
+    }
+  })();
+  true;
+`;
+
+export const buildSwitchCardJs = (index, timeoutMs = 3500) => `
+  (function() {
+    try {
+      var sel = document.querySelector('mds-select[id="select-credit-card-account"]');
+      if (!sel) {
+        window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'CARD_SWITCH_ERROR', message: 'Dropdown not found' }));
+        return;
+      }
+      var opts = sel.querySelectorAll('mds-select-option');
+      var target = opts[${index}];
+      if (!target) {
+        window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'CARD_SWITCH_ERROR', message: 'Card index out of range' }));
+        return;
+      }
+      target.click();
+      sel.dispatchEvent(new Event('change', { bubbles: true }));
+      setTimeout(function() {
+        var updated = sel.querySelector('mds-select-option[selected="true"]');
+        var label = updated ? (updated.getAttribute('label') || '') : '';
+        window.ReactNativeWebView.postMessage(JSON.stringify({
+          type: 'CARD_SWITCHED',
+          cardLabel: label,
+          expectedIndex: ${index},
+        }));
+      }, ${timeoutMs});
+    } catch(e) {
+      window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'CARD_SWITCH_ERROR', message: e.message }));
+    }
+  })();
+  true;
+`;


### PR DESCRIPTION
## Summary
Adds Amex offer sync and refactors all bank-specific JS out of `SyncWebView.js` into focused modules.

## New Structure
```
mobile/components/
  SyncWebView.js          ← orchestrator only (modal, state, message routing)
  sync/
    bankConfig.js         ← BANK_CONFIG for all banks
    chaseSync.js          ← Chase JS: DETECT_CARDS_JS, buildSwitchCardJs
    amexSync.js           ← Amex JS: AMEX_OPEN_AND_DETECT_JS, buildAmexSwitchCardJs
    captureJs.js          ← shared: buildCaptureJs, parseCardLabel
```

## Amex Implementation
- **Card detection:** Opens `simple_switcher_combobox` → reads `[role="option"][data-testid*="CARD_PRODUCT"]` options (filters out checking/savings accounts)
- **Card switching:** Click combobox → click target option by `data-testid` → confirm via display label
- **Offers page detection:** URL-based (`/benefits/offers`) on `onLoadEnd`
- **Capture:** Shared `buildCaptureJs` reads card label from Amex combobox display or Chase mds-select

## Adding Future Banks
1. Add entry to `sync/bankConfig.js`
2. Create `sync/<bank>Sync.js`
3. Wire up in `handleLoadEnd` + `handleMessage` in `SyncWebView.js`

## No breaking changes
- Chase sync behaviour unchanged
- All existing message types (`CARDS_DETECTED`, `CARD_SWITCHED`, `CAPTURE_HTML`) preserved