### PR TITLE
feat: Amex activated offers — two-phase sync (eligible + enrolled)

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -6,14 +6,15 @@ import express from 'express';
 import cors from 'cors';
 import searchRoutes from './routes/search.js';
 import offersRoutes from './routes/offers.js';
+import debugRoutes from './routes/debug.js';
 
 const app = express();
 const PORT = process.env.PORT || 3001;
 
 // Middleware
 app.use(cors());
-// Raised from default 100KB to 512KB to handle bank offers HTML payloads
-app.use(express.json({ limit: '512kb' }));
+// Raised to 10MB to support debug offersList dumps
+app.use(express.json({ limit: '10mb' }));
 
 // Request logging
 app.use((req, res, next) => {
@@ -24,6 +25,7 @@ app.use((req, res, next) => {
 // Routes
 app.use('/api/search', searchRoutes);
 app.use('/api/offers', offersRoutes);
+app.use('/api/debug', debugRoutes);
 
 // Health check
 app.get('/api/health', (req, res) => {

--- a/api/lib/parsers/amex.js
+++ b/api/lib/parsers/amex.js
@@ -1,24 +1,5 @@
 // ─────────────────────────────────────────────
 // AMEX OFFERS PARSER — JSON-based
-// Parses the ReadOffersHubPresentation API response intercepted
-// by buildAmexJsonCaptureJs() in mobile/components/sync/amexSync.js
-//
-// Response shape (Mar 2026):
-//   {
-//     recommendedOffers: { offersList: { page1: [ ...offerObjects ] } },
-//     addedToCard:       { offersList: { page1: [ ...offerObjects ] } },
-//   }
-//
-// Each offer object contains:
-//   offerId, title, shortDescription, businessName,
-//   currencyType ('MR' | 'USD' | 'PERCENT'),
-//   rewardValue (number), minimumSpend (number),
-//   offerEndDate ('YYYY-MM-DD'),
-//   redemptionType (e.g. 'CARD_LINKED')
-//
-// parseAmexEligibleOffers  → reads recommendedOffers (phase: eligible)
-// parseAmexEnrolledOffers  → reads addedToCard       (phase: enrolled)
-// parseAmexOffers          → auto-routes by phase string (called from offers.js)
 // ─────────────────────────────────────────────
 
 function mapOffer(offer, isActivated) {
@@ -27,11 +8,9 @@ function mapOffer(offer, isActivated) {
   const merchant    = (offer.businessName    || '').trim();
 
   if (!merchant) {
-    console.log('[amex:mapOffer] skipping offer — no businessName. offerId:', offer.offerId);
     return null;
   }
 
-  // ── Cashback ────────────────────────────────────────────
   const currency = (offer.currencyType || '').toUpperCase();
   const cashbackAmount = parseFloat(offer.rewardValue) || 0;
   let cashbackType;
@@ -44,17 +23,13 @@ function mapOffer(offer, isActivated) {
     cashbackType = 'fixed';
   }
 
-  // ── Minimum spend ───────────────────────────────────────
   const minimumSpend = parseFloat(offer.minimumSpend) || 0;
 
-  // ── Expiry ──────────────────────────────────────────────
   let expiryDate = null;
   if (offer.offerEndDate) {
     const parsed = new Date(offer.offerEndDate);
     if (!isNaN(parsed.getTime())) {
       expiryDate = parsed.toISOString();
-    } else {
-      console.log('[amex:mapOffer] invalid offerEndDate:', offer.offerEndDate, 'for offerId:', offer.offerId);
     }
   }
 
@@ -72,57 +47,35 @@ function mapOffer(offer, isActivated) {
 }
 
 function extractOfferList(container, label) {
-  if (!container) {
-    console.log(`[amex:extractOfferList] container "${label}" is missing`);
-    return [];
-  }
+  if (!container) return [];
   const offersList = container.offersList;
-  if (!offersList) {
-    console.log(`[amex:extractOfferList] "${label}" has no offersList. Keys:`, Object.keys(container));
-    return [];
-  }
+  if (!offersList) return [];
+
   const pages = Object.keys(offersList).sort();
-  console.log(`[amex:extractOfferList] "${label}" pages:`, pages);
   const all = pages.flatMap(key => Array.isArray(offersList[key]) ? offersList[key] : []);
-  console.log(`[amex:extractOfferList] "${label}" total raw offers across all pages:`, all.length);
+
   if (all.length > 0) {
-    const sample = all[0];
-    console.log(`[amex:extractOfferList] "${label}" first offer sample:`, JSON.stringify({
-      offerId:      sample.offerId,
-      businessName: sample.businessName,
-      title:        sample.title,
-      currencyType: sample.currencyType,
-      rewardValue:  sample.rewardValue,
-      minimumSpend: sample.minimumSpend,
-      offerEndDate: sample.offerEndDate,
-    }));
+    console.log(`[amex:sample] first offer from "${label}":\n`, JSON.stringify(all[0], null, 2));
   }
+
   return all;
 }
 
 export function parseAmexEligibleOffers(json) {
-  console.log('[parseAmexEligibleOffers] top-level keys:', Object.keys(json || {}));
   const raw    = extractOfferList(json?.recommendedOffers, 'recommendedOffers');
   const offers = raw.map(o => mapOffer(o, false)).filter(Boolean);
-  console.log(`[parseAmexEligibleOffers] result: ${offers.length} valid offers from ${raw.length} raw`);
+  console.log(`[parseAmexEligibleOffers] ${offers.length} valid offers from ${raw.length} raw`);
   return offers;
 }
 
 export function parseAmexEnrolledOffers(json) {
-  console.log('[parseAmexEnrolledOffers] top-level keys:', Object.keys(json || {}));
   const raw    = extractOfferList(json?.addedToCard, 'addedToCard');
   const offers = raw.map(o => mapOffer(o, true)).filter(Boolean);
-  console.log(`[parseAmexEnrolledOffers] result: ${offers.length} valid offers from ${raw.length} raw`);
+  console.log(`[parseAmexEnrolledOffers] ${offers.length} valid offers from ${raw.length} raw`);
   return offers;
 }
 
-/**
- * Auto-routes by phase. Called from api/routes/offers.js.
- * @param {object} json  — parsed ReadOffersHubPresentation response
- * @param {string} phase — 'eligible' | 'enrolled'
- */
 export function parseAmexOffers(json, phase) {
-  console.log(`[parseAmexOffers] routing to phase=${phase}`);
   if (phase === 'enrolled') return parseAmexEnrolledOffers(json);
   return parseAmexEligibleOffers(json);
 }

--- a/api/lib/parsers/amex.js
+++ b/api/lib/parsers/amex.js
@@ -26,8 +26,6 @@ function mapOffer(offer, isActivated) {
     return null;
   }
 
-  console.log(`[PARSED] "${merchantName}"`);
-
   const offerDescription = offer.shortDescription || '';
   const category = (offer.applicableCategories?.[0]?.optionType || 'OTHER').toLowerCase();
   const expiryDate = parseExpiryDate(offer.expiration?.text);
@@ -61,8 +59,9 @@ export function parseAmexEligibleOffers(json) {
     console.log(`[parseAmexEligibleOffers] offersMap keys:`, Object.keys(json.offersMap));
   }
 
-  const raw    = extractOfferList(json?.recommendedOffers);
+  const raw = extractOfferList(json?.recommendedOffers);
   console.log(`[parseAmexEligibleOffers] raw offer count: ${raw.length}`);
+  console.log(`[parseAmexEligibleOffers] titles: ${JSON.stringify(raw.map(o => o.title))}`);
 
   const offers = raw.map(o => mapOffer(o, false)).filter(Boolean);
   console.log(`✅ [parse:amex] eligible: ${offers.length} parsed, ${raw.length - offers.length} skipped`);
@@ -71,7 +70,7 @@ export function parseAmexEligibleOffers(json) {
 
 export function parseAmexEnrolledOffers(json) {
   const container = json?.addedToCardViewAll ?? json?.addedToCard;
-  const raw    = extractOfferList(container);
+  const raw = extractOfferList(container);
   const offers = raw.map(o => mapOffer(o, true)).filter(Boolean);
   console.log(`✅ [parse:amex] enrolled: ${offers.length} offers parsed (${raw.length} raw)`);
   return offers;

--- a/api/lib/parsers/amex.js
+++ b/api/lib/parsers/amex.js
@@ -26,11 +26,14 @@ function mapOffer(offer, isActivated) {
   const description = offer.shortDescription || title;
   const merchant    = (offer.businessName    || '').trim();
 
-  if (!merchant) return null;
+  if (!merchant) {
+    console.log('[amex:mapOffer] skipping offer — no businessName. offerId:', offer.offerId);
+    return null;
+  }
 
   // ── Cashback ────────────────────────────────────────────
   const currency = (offer.currencyType || '').toUpperCase();
-  let cashbackAmount = parseFloat(offer.rewardValue) || 0;
+  const cashbackAmount = parseFloat(offer.rewardValue) || 0;
   let cashbackType;
 
   if (currency === 'MR') {
@@ -38,7 +41,6 @@ function mapOffer(offer, isActivated) {
   } else if (currency === 'PERCENT') {
     cashbackType = 'percent';
   } else {
-    // USD or unknown — treat as fixed dollar
     cashbackType = 'fixed';
   }
 
@@ -49,7 +51,11 @@ function mapOffer(offer, isActivated) {
   let expiryDate = null;
   if (offer.offerEndDate) {
     const parsed = new Date(offer.offerEndDate);
-    if (!isNaN(parsed.getTime())) expiryDate = parsed.toISOString();
+    if (!isNaN(parsed.getTime())) {
+      expiryDate = parsed.toISOString();
+    } else {
+      console.log('[amex:mapOffer] invalid offerEndDate:', offer.offerEndDate, 'for offerId:', offer.offerId);
+    }
   }
 
   return {
@@ -65,25 +71,48 @@ function mapOffer(offer, isActivated) {
   };
 }
 
-function extractOfferList(container) {
-  const offersList = container?.offersList || {};
-  // Amex paginates as page1, page2, ... — collect all pages
-  return Object.keys(offersList)
-    .sort()
-    .flatMap(key => Array.isArray(offersList[key]) ? offersList[key] : []);
+function extractOfferList(container, label) {
+  if (!container) {
+    console.log(`[amex:extractOfferList] container "${label}" is missing`);
+    return [];
+  }
+  const offersList = container.offersList;
+  if (!offersList) {
+    console.log(`[amex:extractOfferList] "${label}" has no offersList. Keys:`, Object.keys(container));
+    return [];
+  }
+  const pages = Object.keys(offersList).sort();
+  console.log(`[amex:extractOfferList] "${label}" pages:`, pages);
+  const all = pages.flatMap(key => Array.isArray(offersList[key]) ? offersList[key] : []);
+  console.log(`[amex:extractOfferList] "${label}" total raw offers across all pages:`, all.length);
+  if (all.length > 0) {
+    const sample = all[0];
+    console.log(`[amex:extractOfferList] "${label}" first offer sample:`, JSON.stringify({
+      offerId:      sample.offerId,
+      businessName: sample.businessName,
+      title:        sample.title,
+      currencyType: sample.currencyType,
+      rewardValue:  sample.rewardValue,
+      minimumSpend: sample.minimumSpend,
+      offerEndDate: sample.offerEndDate,
+    }));
+  }
+  return all;
 }
 
 export function parseAmexEligibleOffers(json) {
-  const raw = extractOfferList(json?.recommendedOffers);
+  console.log('[parseAmexEligibleOffers] top-level keys:', Object.keys(json || {}));
+  const raw    = extractOfferList(json?.recommendedOffers, 'recommendedOffers');
   const offers = raw.map(o => mapOffer(o, false)).filter(Boolean);
-  console.log(`[parseAmexEligibleOffers] offers parsed: ${offers.length} (from ${raw.length} raw)`);
+  console.log(`[parseAmexEligibleOffers] result: ${offers.length} valid offers from ${raw.length} raw`);
   return offers;
 }
 
 export function parseAmexEnrolledOffers(json) {
-  const raw = extractOfferList(json?.addedToCard);
+  console.log('[parseAmexEnrolledOffers] top-level keys:', Object.keys(json || {}));
+  const raw    = extractOfferList(json?.addedToCard, 'addedToCard');
   const offers = raw.map(o => mapOffer(o, true)).filter(Boolean);
-  console.log(`[parseAmexEnrolledOffers] offers parsed: ${offers.length} (from ${raw.length} raw)`);
+  console.log(`[parseAmexEnrolledOffers] result: ${offers.length} valid offers from ${raw.length} raw`);
   return offers;
 }
 
@@ -93,6 +122,7 @@ export function parseAmexEnrolledOffers(json) {
  * @param {string} phase — 'eligible' | 'enrolled'
  */
 export function parseAmexOffers(json, phase) {
+  console.log(`[parseAmexOffers] routing to phase=${phase}`);
   if (phase === 'enrolled') return parseAmexEnrolledOffers(json);
   return parseAmexEligibleOffers(json);
 }

--- a/api/lib/parsers/amex.js
+++ b/api/lib/parsers/amex.js
@@ -1,64 +1,50 @@
 // ─────────────────────────────────────────────
 // AMEX OFFERS PARSER — JSON-based
+// Parses the ReadOffersHubPresentation API response intercepted
+// by buildAmexJsonCaptureJs() in mobile/components/sync/amexSync.js
 // ─────────────────────────────────────────────
 
+function parseExpiryDate(expirationText) {
+  if (!expirationText) return null;
+  // e.g. "Expires 3/15/26"
+  const match = expirationText.match(/(\d{1,2})\/(\d{1,2})\/(\d{2,4})/);
+  if (!match) return null;
+  const [, month, day, year] = match;
+  const fullYear = year.length === 2 ? `20${year}` : year;
+  const parsed = new Date(`${fullYear}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`);
+  return isNaN(parsed.getTime()) ? null : parsed.toISOString();
+}
+
 function mapOffer(offer, isActivated) {
-  const title       = offer.title            || '';
-  const description = offer.shortDescription || title;
-  const merchant    = (offer.businessName    || '').trim();
+  const merchantName = (offer.title || '').trim();
+  if (!merchantName) return null;
 
-  if (!merchant) {
-    return null;
-  }
-
-  const currency = (offer.currencyType || '').toUpperCase();
-  const cashbackAmount = parseFloat(offer.rewardValue) || 0;
-  let cashbackType;
-
-  if (currency === 'MR') {
-    cashbackType = 'points';
-  } else if (currency === 'PERCENT') {
-    cashbackType = 'percent';
-  } else {
-    cashbackType = 'fixed';
-  }
-
-  const minimumSpend = parseFloat(offer.minimumSpend) || 0;
-
-  let expiryDate = null;
-  if (offer.offerEndDate) {
-    const parsed = new Date(offer.offerEndDate);
-    if (!isNaN(parsed.getTime())) {
-      expiryDate = parsed.toISOString();
-    }
-  }
+  const offerDescription = offer.shortDescription || '';
+  const category = (offer.applicableCategories?.[0]?.optionType || 'OTHER').toLowerCase();
+  const expiryDate = parseExpiryDate(offer.expiration?.text);
+  const activated = isActivated ?? (offer.enrollmentDetails?.status === 'ENROLLED');
 
   return {
-    merchantName:     merchant,
-    offerDescription: description,
-    cashbackAmount,
-    cashbackType,
-    minimumSpend,
-    category:         'other',
+    merchantName,
+    offerDescription,
+    cashbackAmount: null,
+    cashbackType:   null,
+    minimumSpend:   null,
+    category,
     expiryDate,
-    isActivated,
-    offerDeepLink:    offer.offerId ? `https://global.americanexpress.com/offers?offerId=${offer.offerId}` : null,
+    isActivated:    activated,
+    offerDeepLink:  offer.offerId
+      ? `https://global.americanexpress.com/offers?offerId=${encodeURIComponent(offer.offerId)}`
+      : null,
   };
 }
 
 function extractOfferList(container, label) {
-  if (!container) return [];
-  const offersList = container.offersList;
-  if (!offersList) return [];
-
-  const pages = Object.keys(offersList).sort();
-  const all = pages.flatMap(key => Array.isArray(offersList[key]) ? offersList[key] : []);
-
-  if (all.length > 0) {
-    console.log(`[amex:sample] first offer from "${label}":\n`, JSON.stringify(all[0], null, 2));
-  }
-
-  return all;
+  if (!container?.offersList) return [];
+  const pages = Object.keys(container.offersList).sort();
+  return pages.flatMap(key =>
+    Array.isArray(container.offersList[key]) ? container.offersList[key] : []
+  );
 }
 
 export function parseAmexEligibleOffers(json) {
@@ -75,6 +61,11 @@ export function parseAmexEnrolledOffers(json) {
   return offers;
 }
 
+/**
+ * Auto-routes by phase. Called from api/routes/offers.js.
+ * @param {object} json  — parsed ReadOffersHubPresentation response
+ * @param {string} phase — 'eligible' | 'enrolled'
+ */
 export function parseAmexOffers(json, phase) {
   if (phase === 'enrolled') return parseAmexEnrolledOffers(json);
   return parseAmexEligibleOffers(json);

--- a/api/lib/parsers/amex.js
+++ b/api/lib/parsers/amex.js
@@ -21,7 +21,12 @@ function mapOffer(offer, isActivated) {
   }
 
   const merchantName = (offer.title || '').trim();
-  if (!merchantName) return null;
+  if (!merchantName) {
+    console.warn(`[SKIPPED] offerId="${offer.offerId}" — empty/missing title`);
+    return null;
+  }
+
+  console.log(`[PARSED] "${merchantName}"`);
 
   const offerDescription = offer.shortDescription || '';
   const category = (offer.applicableCategories?.[0]?.optionType || 'OTHER').toLowerCase();
@@ -52,14 +57,15 @@ function extractOfferList(container) {
 }
 
 export function parseAmexEligibleOffers(json) {
-  // Debug: log offersMap keys if present to check for missing offers
   if (json?.offersMap) {
     console.log(`[parseAmexEligibleOffers] offersMap keys:`, Object.keys(json.offersMap));
   }
 
   const raw    = extractOfferList(json?.recommendedOffers);
+  console.log(`[parseAmexEligibleOffers] raw offer count: ${raw.length}`);
+
   const offers = raw.map(o => mapOffer(o, false)).filter(Boolean);
-  console.log(`✅ [parse:amex] eligible: ${offers.length} offers parsed (${raw.length} raw)`);
+  console.log(`✅ [parse:amex] eligible: ${offers.length} parsed, ${raw.length - offers.length} skipped`);
   return offers;
 }
 

--- a/api/lib/parsers/amex.js
+++ b/api/lib/parsers/amex.js
@@ -6,7 +6,6 @@
 
 function parseExpiryDate(expirationText) {
   if (!expirationText) return null;
-  // e.g. "Expires 3/15/26"
   const match = expirationText.match(/(\d{1,2})\/(\d{1,2})\/(\d{2,4})/);
   if (!match) return null;
   const [, month, day, year] = match;
@@ -16,7 +15,6 @@ function parseExpiryDate(expirationText) {
 }
 
 function mapOffer(offer, isActivated) {
-  // Only capture merchant offers — skip CARD (bank promos, referrals, CreditSecure, etc.)
   if (offer.offerType !== 'MERCHANT') {
     console.log(`[SKIPPED] offerType=${offer.offerType} title="${offer.title}"`);
     return null;
@@ -54,22 +52,22 @@ function extractOfferList(container) {
 }
 
 export function parseAmexEligibleOffers(json) {
+  // Debug: log offersMap keys if present to check for missing offers
+  if (json?.offersMap) {
+    console.log(`[parseAmexEligibleOffers] offersMap keys:`, Object.keys(json.offersMap));
+  }
+
   const raw    = extractOfferList(json?.recommendedOffers);
-  const total  = raw.length;
   const offers = raw.map(o => mapOffer(o, false)).filter(Boolean);
-  const skipped = total - offers.length;
-  console.log(`[parseAmexEligibleOffers] ${offers.length} merchant offers captured, ${skipped} non-merchant skipped (${total} raw)`);
+  console.log(`✅ [parse:amex] eligible: ${offers.length} offers parsed (${raw.length} raw)`);
   return offers;
 }
 
 export function parseAmexEnrolledOffers(json) {
-  // Enrolled page returns addedToCardViewAll, not addedToCard
   const container = json?.addedToCardViewAll ?? json?.addedToCard;
   const raw    = extractOfferList(container);
-  const total  = raw.length;
   const offers = raw.map(o => mapOffer(o, true)).filter(Boolean);
-  const skipped = total - offers.length;
-  console.log(`[parseAmexEnrolledOffers] ${offers.length} merchant offers captured, ${skipped} non-merchant skipped (${total} raw)`);
+  console.log(`✅ [parse:amex] enrolled: ${offers.length} offers parsed (${raw.length} raw)`);
   return offers;
 }
 

--- a/api/lib/parsers/amex.js
+++ b/api/lib/parsers/amex.js
@@ -1,126 +1,98 @@
 // ─────────────────────────────────────────────
-// AMEX OFFERS PARSER
-// Parses raw HTML from global.americanexpress.com/offers/eligible
-// DOM analysis: Mar 2026
+// AMEX OFFERS PARSER — JSON-based
+// Parses the ReadOffersHubPresentation API response intercepted
+// by buildAmexJsonCaptureJs() in mobile/components/sync/amexSync.js
 //
-// Structure:
-//   [data-testid="listViewContainer"]
-//     > DIV  (one per offer, no data-testid on row itself)
-//       ├─ [data-testid="merchantOfferListAddButton"]   ← not yet added
-//       ├─ [data-testid="merchantOfferSuccessIcon"]     ← already added
-//       ├─ h3                                           ← merchant name
-//       ├─ [data-testid="overflowTextContainer"] x2     ← [0]=title [1]=description
-//       └─ <p> containing "Expires"                     ← expiry
+// Response shape (Mar 2026):
+//   {
+//     recommendedOffers: { offersList: { page1: [ ...offerObjects ] } },
+//     addedToCard:       { offersList: { page1: [ ...offerObjects ] } },
+//   }
 //
-// NOTE: captureJs grabs outerHTML of listViewContainer, so when Cheerio
-// loads it the ROOT element IS listViewContainer — we can't use a
-// descendant selector to find it. We detect both cases:
-//   1. Root IS listViewContainer → select its direct > div children
-//   2. Root is a full page       → find listViewContainer then its > div children
+// Each offer object contains:
+//   offerId, title, shortDescription, businessName,
+//   currencyType ('MR' | 'USD' | 'PERCENT'),
+//   rewardValue (number), minimumSpend (number),
+//   offerEndDate ('YYYY-MM-DD'),
+//   redemptionType (e.g. 'CARD_LINKED')
+//
+// parseAmexEligibleOffers  → reads recommendedOffers (phase: eligible)
+// parseAmexEnrolledOffers  → reads addedToCard       (phase: enrolled)
+// parseAmexOffers          → auto-routes by phase string (called from offers.js)
 // ─────────────────────────────────────────────
-import * as cheerio from 'cheerio';
 
-export function parseAmexOffers(html) {
-  const $ = cheerio.load(html);
-  const offers = [];
+function mapOffer(offer, isActivated) {
+  const title       = offer.title            || '';
+  const description = offer.shortDescription || title;
+  const merchant    = (offer.businessName    || '').trim();
 
-  let $rows;
-  const $root = $.root().children().first();
-  const isRootListView = $root.attr('data-testid') === 'listViewContainer';
+  if (!merchant) return null;
 
-  if (isRootListView) {
-    $rows = $root.children('div');
-    console.log(`[parseAmexOffers] root IS listViewContainer, direct div children: ${$rows.length}`);
+  // ── Cashback ────────────────────────────────────────────
+  const currency = (offer.currencyType || '').toUpperCase();
+  let cashbackAmount = parseFloat(offer.rewardValue) || 0;
+  let cashbackType;
+
+  if (currency === 'MR') {
+    cashbackType = 'points';
+  } else if (currency === 'PERCENT') {
+    cashbackType = 'percent';
   } else {
-    $rows = $('[data-testid="listViewContainer"]').first().children('div');
-    console.log(`[parseAmexOffers] full page mode, listViewContainer children: ${$rows.length}`);
+    // USD or unknown — treat as fixed dollar
+    cashbackType = 'fixed';
   }
 
-  $rows.each((i, el) => {
-    try {
-      const $el = $(el);
+  // ── Minimum spend ───────────────────────────────────────
+  const minimumSpend = parseFloat(offer.minimumSpend) || 0;
 
-      // ── Filter: skip bank/promo tiles ────────────────────
-      const isAddable   = $el.find('[data-testid="merchantOfferListAddButton"]').length > 0;
-      const isActivated = $el.find('[data-testid="merchantOfferSuccessIcon"]').length > 0;
-      if (!isAddable && !isActivated) return;
+  // ── Expiry ──────────────────────────────────────────────
+  let expiryDate = null;
+  if (offer.offerEndDate) {
+    const parsed = new Date(offer.offerEndDate);
+    if (!isNaN(parsed.getTime())) expiryDate = parsed.toISOString();
+  }
 
-      // ── Merchant Name ─────────────────────────────────
-      const merchantName = $el.find('h3').first().text().trim();
-      if (!merchantName) return;
+  return {
+    merchantName:     merchant,
+    offerDescription: description,
+    cashbackAmount,
+    cashbackType,
+    minimumSpend,
+    category:         'other',
+    expiryDate,
+    isActivated,
+    offerDeepLink:    offer.offerId ? `https://global.americanexpress.com/offers?offerId=${offer.offerId}` : null,
+  };
+}
 
-      // ── Offer Title + Description ───────────────────────
-      const descContainers   = $el.find('[data-testid="overflowTextContainer"]');
-      const offerTitle       = descContainers.eq(0).text().trim();
-      const offerDescription = descContainers.eq(1).text().trim() || offerTitle;
+function extractOfferList(container) {
+  const offersList = container?.offersList || {};
+  // Amex paginates as page1, page2, ... — collect all pages
+  return Object.keys(offersList)
+    .sort()
+    .flatMap(key => Array.isArray(offersList[key]) ? offersList[key] : []);
+}
 
-      // ── Cashback Parsing ─────────────────────────────
-      // Search both title and description; description usually has the cashback value
-      const searchText = offerTitle + ' ' + offerDescription;
-
-      let cashbackAmount = 0;
-      let cashbackType   = 'fixed';
-
-      // Handle "Earn +5 Membership Rewards" or "earn 10,000 Membership Rewards"
-      const pointsMatch  = searchText.match(/[Ee]arn\s+\+?([\d,]+(?:\.\d+)?)\s+[Mm]embership\s+[Rr]ewards/);
-      const percentMatch = searchText.match(/([\d.]+)%\s+back/);
-      // Match dollar amount after "earn" (handles "earn $10 back", "earn $25")
-      const dollarMatch  = searchText.match(/[Ee]arn\s+\$([0-9,]+(?:\.[0-9]+)?)/);
-
-      if (pointsMatch) {
-        cashbackAmount = parseFloat(pointsMatch[1].replace(/,/g, ''));
-        cashbackType   = 'points';
-      } else if (percentMatch) {
-        cashbackAmount = parseFloat(percentMatch[1]);
-        cashbackType   = 'percent';
-      } else if (dollarMatch) {
-        cashbackAmount = parseFloat(dollarMatch[1].replace(/,/g, ''));
-        cashbackType   = 'fixed';
-      }
-
-      // ── Minimum Spend ────────────────────────────────
-      let minimumSpend = 0;
-      const combinedText  = searchText.toLowerCase();
-      // Strip commas from amounts like $1,000
-      const minSpendMatch = combinedText.match(/spend\s+\$?([\d,]+(?:\.\d+)?)/);
-      if (minSpendMatch) minimumSpend = parseFloat(minSpendMatch[1].replace(/,/g, ''));
-
-      // ── Expiry Date ──────────────────────────────────
-      let expiryDate    = null;
-      let isExpiringSoon = false;
-
-      const $expiryP = $el.find('p').filter((_, p) =>
-        $(p).text().toLowerCase().includes('expires')
-      ).first();
-
-      if ($expiryP.length) {
-        isExpiringSoon = ($expiryP.attr('class') || '').includes('color-status-text-critical');
-        const rawExpiry = $expiryP.text().replace(/expires/i, '').trim();
-        const parts = rawExpiry.split('/');
-        if (parts.length === 3) {
-          const [m, d, y] = parts;
-          const fullYear = parseInt(y) < 100 ? 2000 + parseInt(y) : parseInt(y);
-          const parsed   = new Date(fullYear, parseInt(m) - 1, parseInt(d));
-          if (!isNaN(parsed.getTime())) expiryDate = parsed.toISOString();
-        }
-      }
-
-      offers.push({
-        merchantName,
-        offerDescription,
-        cashbackAmount,
-        cashbackType,
-        minimumSpend,
-        category: 'other',
-        expiryDate,
-        isActivated,
-        isExpiringSoon,
-      });
-    } catch (err) {
-      console.error('⚠️ Error parsing Amex offer row:', err);
-    }
-  });
-
-  console.log(`[parseAmexOffers] offers parsed: ${offers.length}`);
+export function parseAmexEligibleOffers(json) {
+  const raw = extractOfferList(json?.recommendedOffers);
+  const offers = raw.map(o => mapOffer(o, false)).filter(Boolean);
+  console.log(`[parseAmexEligibleOffers] offers parsed: ${offers.length} (from ${raw.length} raw)`);
   return offers;
+}
+
+export function parseAmexEnrolledOffers(json) {
+  const raw = extractOfferList(json?.addedToCard);
+  const offers = raw.map(o => mapOffer(o, true)).filter(Boolean);
+  console.log(`[parseAmexEnrolledOffers] offers parsed: ${offers.length} (from ${raw.length} raw)`);
+  return offers;
+}
+
+/**
+ * Auto-routes by phase. Called from api/routes/offers.js.
+ * @param {object} json  — parsed ReadOffersHubPresentation response
+ * @param {string} phase — 'eligible' | 'enrolled'
+ */
+export function parseAmexOffers(json, phase) {
+  if (phase === 'enrolled') return parseAmexEnrolledOffers(json);
+  return parseAmexEligibleOffers(json);
 }

--- a/api/lib/parsers/amex.js
+++ b/api/lib/parsers/amex.js
@@ -17,7 +17,10 @@ function parseExpiryDate(expirationText) {
 
 function mapOffer(offer, isActivated) {
   // Only capture merchant offers — skip CARD (bank promos, referrals, CreditSecure, etc.)
-  if (offer.offerType !== 'MERCHANT') return null;
+  if (offer.offerType !== 'MERCHANT') {
+    console.log(`[SKIPPED] offerType=${offer.offerType} title="${offer.title}"`);
+    return null;
+  }
 
   const merchantName = (offer.title || '').trim();
   if (!merchantName) return null;

--- a/api/lib/parsers/amex.js
+++ b/api/lib/parsers/amex.js
@@ -15,16 +15,10 @@ function parseExpiryDate(expirationText) {
 }
 
 function mapOffer(offer, isActivated) {
-  if (offer.offerType !== 'MERCHANT') {
-    console.log(`[SKIPPED] offerType=${offer.offerType} title="${offer.title}"`);
-    return null;
-  }
+  if (offer.offerType !== 'MERCHANT') return null;
 
   const merchantName = (offer.title || '').trim();
-  if (!merchantName) {
-    console.warn(`[SKIPPED] offerId="${offer.offerId}" — empty/missing title`);
-    return null;
-  }
+  if (!merchantName) return null;
 
   const offerDescription = offer.shortDescription || '';
   const category = (offer.applicableCategories?.[0]?.optionType || 'OTHER').toLowerCase();
@@ -55,25 +49,15 @@ function extractOfferList(container) {
 }
 
 export function parseAmexEligibleOffers(json) {
-  if (json?.offersMap) {
-    console.log(`[parseAmexEligibleOffers] offersMap keys:`, Object.keys(json.offersMap));
-  }
-
   const raw = extractOfferList(json?.recommendedOffers);
-  console.log(`[parseAmexEligibleOffers] raw offer count: ${raw.length}`);
-  console.log(`[parseAmexEligibleOffers] titles: ${JSON.stringify(raw.map(o => o.title))}`);
-
   const offers = raw.map(o => mapOffer(o, false)).filter(Boolean);
-  console.log(`✅ [parse:amex] eligible: ${offers.length} parsed, ${raw.length - offers.length} skipped`);
   return offers;
 }
 
 export function parseAmexEnrolledOffers(json) {
   const container = json?.addedToCardViewAll ?? json?.addedToCard;
   const raw = extractOfferList(container);
-  const offers = raw.map(o => mapOffer(o, true)).filter(Boolean);
-  console.log(`✅ [parse:amex] enrolled: ${offers.length} offers parsed (${raw.length} raw)`);
-  return offers;
+  return raw.map(o => mapOffer(o, true)).filter(Boolean);
 }
 
 /**

--- a/api/lib/parsers/amex.js
+++ b/api/lib/parsers/amex.js
@@ -16,6 +16,9 @@ function parseExpiryDate(expirationText) {
 }
 
 function mapOffer(offer, isActivated) {
+  // Only capture merchant offers — skip CARD (bank promos, referrals, CreditSecure, etc.)
+  if (offer.offerType !== 'MERCHANT') return null;
+
   const merchantName = (offer.title || '').trim();
   if (!merchantName) return null;
 
@@ -39,7 +42,7 @@ function mapOffer(offer, isActivated) {
   };
 }
 
-function extractOfferList(container, label) {
+function extractOfferList(container) {
   if (!container?.offersList) return [];
   const pages = Object.keys(container.offersList).sort();
   return pages.flatMap(key =>
@@ -48,16 +51,22 @@ function extractOfferList(container, label) {
 }
 
 export function parseAmexEligibleOffers(json) {
-  const raw    = extractOfferList(json?.recommendedOffers, 'recommendedOffers');
+  const raw    = extractOfferList(json?.recommendedOffers);
+  const total  = raw.length;
   const offers = raw.map(o => mapOffer(o, false)).filter(Boolean);
-  console.log(`[parseAmexEligibleOffers] ${offers.length} valid offers from ${raw.length} raw`);
+  const skipped = total - offers.length;
+  console.log(`[parseAmexEligibleOffers] ${offers.length} merchant offers captured, ${skipped} non-merchant skipped (${total} raw)`);
   return offers;
 }
 
 export function parseAmexEnrolledOffers(json) {
-  const raw    = extractOfferList(json?.addedToCard, 'addedToCard');
+  // Enrolled page returns addedToCardViewAll, not addedToCard
+  const container = json?.addedToCardViewAll ?? json?.addedToCard;
+  const raw    = extractOfferList(container);
+  const total  = raw.length;
   const offers = raw.map(o => mapOffer(o, true)).filter(Boolean);
-  console.log(`[parseAmexEnrolledOffers] ${offers.length} valid offers from ${raw.length} raw`);
+  const skipped = total - offers.length;
+  console.log(`[parseAmexEnrolledOffers] ${offers.length} merchant offers captured, ${skipped} non-merchant skipped (${total} raw)`);
   return offers;
 }
 

--- a/api/lib/shared/offerUtils.js
+++ b/api/lib/shared/offerUtils.js
@@ -88,10 +88,10 @@ export const buildResultsForCategory = (category, allCards = []) => {
     .sort((a, b) => b.rate - a.rate);
 };
 
-export const generateOfferId = (merchantName, cashbackAmount, expiryDate, cardName = '') => {
-  const raw = `${merchantName.toLowerCase().trim()}_${cashbackAmount}_${cardName.toLowerCase().trim()}_${expiryDate}`;
-  // No truncation — full encoded string prevents collisions between offers
-  // with same merchant/expiry across different cards or same card.
+// phase is included so eligible and enrolled offers for the same merchant
+// never collide in Firestore even when merchant + expiry are identical.
+export const generateOfferId = (merchantName, cashbackAmount, expiryDate, cardName = '', phase = '') => {
+  const raw = `${merchantName.toLowerCase().trim()}_${cashbackAmount}_${cardName.toLowerCase().trim()}_${expiryDate}_${phase}`;
   return btoa(unescape(encodeURIComponent(raw)))
     .replace(/[^a-zA-Z0-9]/g, '');
 };

--- a/api/lib/shared/offerUtils.js
+++ b/api/lib/shared/offerUtils.js
@@ -90,9 +90,10 @@ export const buildResultsForCategory = (category, allCards = []) => {
 
 export const generateOfferId = (merchantName, cashbackAmount, expiryDate, cardName = '') => {
   const raw = `${merchantName.toLowerCase().trim()}_${cashbackAmount}_${cardName.toLowerCase().trim()}_${expiryDate}`;
-  const encoded = btoa(unescape(encodeURIComponent(raw)))
+  // No truncation — full encoded string prevents collisions between offers
+  // with same merchant/expiry across different cards or same card.
+  return btoa(unescape(encodeURIComponent(raw)))
     .replace(/[^a-zA-Z0-9]/g, '');
-  return encoded.slice(0, 32);
 };
 
 export const generateCardId = (bankName, cardName) => {

--- a/api/routes/debug.js
+++ b/api/routes/debug.js
@@ -1,0 +1,32 @@
+// ─────────────────────────────────────────────
+// DEBUG ROUTE — local dev only
+// POST /api/debug/dump
+// Writes req.body to a timestamped JSON file in api/debug-dumps/
+// REMOVE before deploying to production.
+// ─────────────────────────────────────────────
+import express from 'express';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const router = express.Router();
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DUMP_DIR = path.join(__dirname, '..', 'debug-dumps');
+
+router.post('/dump', (req, res) => {
+  try {
+    if (!fs.existsSync(DUMP_DIR)) fs.mkdirSync(DUMP_DIR, { recursive: true });
+    const label = req.body?.label || 'dump';
+    const ts = new Date().toISOString().replace(/[:.]/g, '-');
+    const filename = `${label}-${ts}.json`;
+    const filepath = path.join(DUMP_DIR, filename);
+    fs.writeFileSync(filepath, JSON.stringify(req.body?.data ?? req.body, null, 2), 'utf8');
+    console.log(`[debug/dump] wrote ${filepath}`);
+    res.json({ ok: true, file: filename });
+  } catch (err) {
+    console.error('[debug/dump] error:', err.message);
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+export default router;

--- a/api/routes/offers.js
+++ b/api/routes/offers.js
@@ -1,4 +1,4 @@
-// ─────────────────────────────────────────────
+// ─────────────────────────────────────────────────────────────────────
 // OFFERS ROUTES
 // POST /api/offers/sync  — sync pre-parsed offers from Chrome extension
 // POST /api/offers/parse — parse raw data from mobile WebView + sync
@@ -8,7 +8,7 @@
 //   Amex  → { json: object,  bank: 'amex',  cardName, phase: 'eligible'|'enrolled' }
 //
 // Storage: /users/{userId}/offers/{offerId}  (subcollection per user)
-// ─────────────────────────────────────────────
+// ─────────────────────────────────────────────────────────────────────
 import express from 'express';
 import { db, auth } from '../config/firebase.js';
 import { FieldValue, Timestamp } from 'firebase-admin/firestore';
@@ -41,12 +41,13 @@ async function verifyToken(req, res) {
   }
 }
 
-async function writeOffersToDB(offers, { userId, bank, cardName }) {
+async function writeOffersToDB(offers, { userId, bank, cardName, phase }) {
   const userOffersRef = db.collection('users').doc(userId).collection('offers');
 
   const existingSnap = await userOffersRef
     .where('bank', '==', bank)
     .where('cardName', '==', cardName)
+    .where('phase', '==', phase)
     .get();
   const existingIds = new Set(existingSnap.docs.map(d => d.id));
 
@@ -64,7 +65,8 @@ async function writeOffersToDB(offers, { userId, bank, cardName }) {
         offer.merchantName,
         offer.cashbackAmount,
         expiryDate,
-        cardName
+        cardName,
+        phase
       );
 
       const offerDoc = {
@@ -84,6 +86,7 @@ async function writeOffersToDB(offers, { userId, bank, cardName }) {
         offerDeepLink:      offer.offerDeepLink || null,
         bank,
         cardName,
+        phase,
         syncedAt:           FieldValue.serverTimestamp(),
       };
 
@@ -122,7 +125,7 @@ router.post('/sync', async (req, res) => {
       return res.status(400).json({ error: 'bank and cardName are required' });
     }
 
-    const { newCount, updatedCount, errorCount } = await writeOffersToDB(offers, { userId, bank, cardName });
+    const { newCount, updatedCount, errorCount } = await writeOffersToDB(offers, { userId, bank, cardName, phase: '' });
     console.log(`✅ [sync] ${bank} — ${cardName}: ${newCount} new, ${updatedCount} updated`);
 
     res.json({ success: true, newCount, updatedCount, errorCount, total: offers.length });
@@ -152,7 +155,7 @@ router.post('/parse', async (req, res) => {
 
     let offers;
 
-    // ── Amex: JSON path ────────────────────────────────────────────
+    // ── Amex: JSON path ──────────────────────────────────────────
     if (bank === 'amex') {
       const { json } = req.body;
       if (!json || typeof json !== 'object') {
@@ -162,7 +165,7 @@ router.post('/parse', async (req, res) => {
       offers = parseAmexOffers(json, resolvedPhase);
     }
 
-    // ── Chase: HTML path (unchanged) ─────────────────────────────
+    // ── Chase: HTML path ─────────────────────────────────────────
     else {
       const { html } = req.body;
       if (!html || typeof html !== 'string') {
@@ -175,10 +178,12 @@ router.post('/parse', async (req, res) => {
       return res.json({ success: true, offers: [], newCount: 0, updatedCount: 0, errorCount: 0, bank, message: 'No offers found.' });
     }
 
+    const resolvedPhase    = bank === 'amex' ? (phase === 'enrolled' ? 'enrolled' : 'eligible') : (phase || '');
     const resolvedCardName = cardName || (bank === 'chase' ? 'Chase Card' : 'Amex Card');
-    const { newCount, updatedCount, errorCount } = await writeOffersToDB(offers, { userId, bank, cardName: resolvedCardName });
+    const { newCount, updatedCount, errorCount } = await writeOffersToDB(offers, { userId, bank, cardName: resolvedCardName, phase: resolvedPhase });
 
-    console.log(`✅ [parse] ${bank} — ${resolvedCardName} (${phase}): ${newCount} new, ${updatedCount} updated`);
+    console.log(`✅ [parse] ${bank} — ${resolvedCardName} (${resolvedPhase}): ${offers.length} total, ${newCount} new, ${updatedCount} updated`);
+    console.log(`   [${resolvedPhase}] merchants: ${offers.map(o => o.merchantName).join(', ')}`);
 
     res.json({ success: true, synced: offers.length, newCount, updatedCount, errorCount, bank, cardName: resolvedCardName });
   } catch (error) {

--- a/api/routes/offers.js
+++ b/api/routes/offers.js
@@ -8,7 +8,6 @@
 //   Amex  → { json: object,  bank: 'amex',  cardName, phase: 'eligible'|'enrolled' }
 //
 // Storage: /users/{userId}/offers/{offerId}  (subcollection per user)
-// Cleanup: expired offers are purged on every sync (no Firestore TTL needed)
 // ─────────────────────────────────────────────
 import express from 'express';
 import { db, auth } from '../config/firebase.js';
@@ -43,26 +42,8 @@ async function verifyToken(req, res) {
   }
 }
 
-async function purgeExpiredOffers(userOffersRef, bank) {
-  const now = Timestamp.now();
-  const expired = await userOffersRef
-    .where('bank', '==', bank)
-    .where('expiresAt', '<', now)
-    .get();
-
-  if (expired.empty) return 0;
-
-  const batch = db.batch();
-  expired.docs.forEach(doc => batch.delete(doc.ref));
-  await batch.commit();
-  console.log(`🗑️  Purged ${expired.size} expired ${bank} offers`);
-  return expired.size;
-}
-
 async function writeOffersToDB(offers, { userId, bank, cardName }) {
   const userOffersRef = db.collection('users').doc(userId).collection('offers');
-
-  await purgeExpiredOffers(userOffersRef, bank);
 
   // Fetch all existing offer IDs for this card in one read
   const existingSnap = await userOffersRef

--- a/api/routes/offers.js
+++ b/api/routes/offers.js
@@ -36,7 +36,6 @@ async function verifyToken(req, res) {
     const idToken = authHeader.split('Bearer ')[1];
     return await auth.verifyIdToken(idToken);
   } catch (error) {
-    console.error('Token verification failed:', error);
     res.status(401).json({ error: 'Invalid authentication token' });
     return null;
   }
@@ -124,7 +123,7 @@ router.post('/sync', async (req, res) => {
     }
 
     const { newCount, updatedCount, errorCount } = await writeOffersToDB(offers, { userId, bank, cardName });
-    console.log(`✅ [sync] done: ${offers.length} parsed → ${newCount} new, ${updatedCount} updated, ${errorCount} errors (${bank} — ${cardName})`);
+    console.log(`✅ [sync] ${bank} — ${cardName}: ${newCount} new, ${updatedCount} updated`);
 
     res.json({ success: true, newCount, updatedCount, errorCount, total: offers.length });
   } catch (error) {
@@ -179,9 +178,9 @@ router.post('/parse', async (req, res) => {
     const resolvedCardName = cardName || (bank === 'chase' ? 'Chase Card' : 'Amex Card');
     const { newCount, updatedCount, errorCount } = await writeOffersToDB(offers, { userId, bank, cardName: resolvedCardName });
 
-    console.log(`✅ [parse] done: ${offers.length} parsed → ${newCount} new, ${updatedCount} updated, ${errorCount} errors (${bank} — ${resolvedCardName})`);
+    console.log(`✅ [parse] ${bank} — ${resolvedCardName} (${phase}): ${newCount} new, ${updatedCount} updated`);
 
-    res.json({ success: true, offers, newCount, updatedCount, errorCount, bank, cardName: resolvedCardName });
+    res.json({ success: true, synced: offers.length, newCount, updatedCount, errorCount, bank, cardName: resolvedCardName });
   } catch (error) {
     console.error('❌ Offers parse error:', error);
     res.status(500).json({ error: 'Failed to parse and sync offers' });

--- a/api/routes/offers.js
+++ b/api/routes/offers.js
@@ -146,7 +146,7 @@ router.post('/parse', async (req, res) => {
     if (!decoded) return;
 
     const userId = decoded.uid;
-    const { html, bank, cardName } = req.body;
+    const { html, bank, cardName, phase } = req.body;
 
     if (!html || typeof html !== 'string') {
       return res.status(400).json({ error: 'html is required and must be a string' });
@@ -156,7 +156,7 @@ router.post('/parse', async (req, res) => {
     }
 
     // DEBUG: log incoming HTML stats
-    console.log(`📥 [parse] bank=${bank} cardName=${cardName} html.length=${html.length}`);
+    console.log(`📥 [parse] bank=${bank} cardName=${cardName} phase=${phase} html.length=${html.length}`);
     console.log(`📥 [parse] html snippet (first 300 chars):`, html.substring(0, 300));
 
     // DEBUG: check if key Amex selectors are present in the HTML
@@ -169,6 +169,14 @@ router.post('/parse', async (req, res) => {
 
     const parseFn = bank === 'chase' ? parseChaseOffers : parseAmexOffers;
     const offers = parseFn(html);
+
+    // For Amex, override isActivated based on phase:
+    // eligible page = all not activated, enrolled page = all activated
+    if (bank === 'amex' && phase) {
+      const activated = phase === 'enrolled';
+      offers.forEach(o => { o.isActivated = activated; });
+      console.log(`🔍 [parse:amex] overriding isActivated=${activated} for all ${offers.length} offers (phase=${phase})`);
+    }
 
     console.log(`🔍 [parse] parsed ${offers.length} offers from ${bank} HTML for user ${userId}`);
     if (offers.length > 0) {

--- a/api/routes/offers.js
+++ b/api/routes/offers.js
@@ -155,6 +155,9 @@ router.post('/parse', async (req, res) => {
     const userId = decoded.uid;
     const { bank, cardName, phase } = req.body;
 
+    console.log(`📥 [parse] bank=${bank} phase=${phase} cardName=${cardName} userId=${userId}`);
+    console.log(`📥 [parse] body keys:`, Object.keys(req.body));
+
     if (!bank || !['chase', 'amex'].includes(bank)) {
       return res.status(400).json({ error: "bank must be 'chase' or 'amex'" });
     }
@@ -165,12 +168,29 @@ router.post('/parse', async (req, res) => {
     if (bank === 'amex') {
       const { json } = req.body;
       if (!json || typeof json !== 'object') {
+        console.error('❌ [parse:amex] json field missing or not an object. typeof json:', typeof json);
         return res.status(400).json({ error: 'json (object) is required for amex' });
       }
       const resolvedPhase = phase === 'enrolled' ? 'enrolled' : 'eligible';
-      console.log(`📥 [parse:amex] phase=${resolvedPhase} cardName=${cardName}`);
+      console.log(`🔍 [parse:amex] phase=${resolvedPhase} cardName=${cardName}`);
+      console.log(`🔍 [parse:amex] json top-level keys:`, Object.keys(json));
+      console.log(`🔍 [parse:amex] recommendedOffers present:`, !!json.recommendedOffers);
+      console.log(`🔍 [parse:amex] addedToCard present:`, !!json.addedToCard);
+      if (json.recommendedOffers?.offersList) {
+        const pages = Object.keys(json.recommendedOffers.offersList);
+        const total = pages.reduce((s, p) => s + (json.recommendedOffers.offersList[p]?.length || 0), 0);
+        console.log(`🔍 [parse:amex] recommendedOffers pages=${JSON.stringify(pages)} totalRaw=${total}`);
+      }
+      if (json.addedToCard?.offersList) {
+        const pages = Object.keys(json.addedToCard.offersList);
+        const total = pages.reduce((s, p) => s + (json.addedToCard.offersList[p]?.length || 0), 0);
+        console.log(`🔍 [parse:amex] addedToCard pages=${JSON.stringify(pages)} totalRaw=${total}`);
+      }
       offers = parseAmexOffers(json, resolvedPhase);
-      console.log(`🔍 [parse:amex] parsed ${offers.length} offers`);
+      console.log(`✅ [parse:amex] parsed ${offers.length} offers`);
+      if (offers.length > 0) {
+        console.log(`✅ [parse:amex] first offer sample:`, JSON.stringify(offers[0]));
+      }
     }
 
     // ── Chase: HTML path (unchanged) ─────────────────────────────
@@ -179,19 +199,24 @@ router.post('/parse', async (req, res) => {
       if (!html || typeof html !== 'string') {
         return res.status(400).json({ error: 'html (string) is required for chase' });
       }
-      console.log(`📥 [parse:chase] cardName=${cardName} html.length=${html.length}`);
+      console.log(`🔍 [parse:chase] cardName=${cardName} html.length=${html.length}`);
       offers = parseChaseOffers(html);
-      console.log(`🔍 [parse:chase] parsed ${offers.length} offers`);
+      console.log(`✅ [parse:chase] parsed ${offers.length} offers`);
+      if (offers.length > 0) {
+        console.log(`✅ [parse:chase] first offer sample:`, JSON.stringify(offers[0]));
+      }
     }
 
     if (offers.length === 0) {
+      console.log(`⚠️ [parse] 0 offers found for ${bank} phase=${phase} — returning empty`);
       return res.json({ success: true, offers: [], synced: 0, bank, message: 'No offers found.' });
     }
 
     const resolvedCardName = cardName || (bank === 'chase' ? 'Chase Card' : 'Amex Card');
+    console.log(`💾 [parse] writing ${offers.length} offers to DB for ${bank} — ${resolvedCardName}`);
     const { syncedCount, skippedCount } = await writeOffersToDB(offers, { userId, bank, cardName: resolvedCardName });
 
-    console.log(`✅ [parse] ${bank} parse+sync complete: ${syncedCount} synced, ${skippedCount} skipped (${resolvedCardName})`);
+    console.log(`✅ [parse] done: ${syncedCount} synced, ${skippedCount} skipped (${bank} — ${resolvedCardName})`);
 
     res.json({ success: true, offers, synced: syncedCount, skipped: skippedCount, bank, cardName: resolvedCardName });
   } catch (error) {

--- a/api/routes/offers.js
+++ b/api/routes/offers.js
@@ -64,9 +64,17 @@ async function writeOffersToDB(offers, { userId, bank, cardName }) {
 
   await purgeExpiredOffers(userOffersRef, bank);
 
+  // Fetch all existing offer IDs for this card in one read
+  const existingSnap = await userOffersRef
+    .where('bank', '==', bank)
+    .where('cardName', '==', cardName)
+    .get();
+  const existingIds = new Set(existingSnap.docs.map(d => d.id));
+
   const batch = db.batch();
-  let syncedCount = 0;
-  let skippedCount = 0;
+  let newCount     = 0;
+  let updatedCount = 0;
+  let errorCount   = 0;
 
   for (const offer of offers) {
     try {
@@ -101,15 +109,20 @@ async function writeOffersToDB(offers, { userId, bank, cardName }) {
       };
 
       batch.set(userOffersRef.doc(offerId), offerDoc, { merge: true });
-      syncedCount++;
+
+      if (existingIds.has(offerId)) {
+        updatedCount++;
+      } else {
+        newCount++;
+      }
     } catch (error) {
       console.error(`❌ Error processing offer "${offer.merchantName}":`, error);
-      skippedCount++;
+      errorCount++;
     }
   }
 
   await batch.commit();
-  return { syncedCount, skippedCount };
+  return { newCount, updatedCount, errorCount };
 }
 
 /**
@@ -131,10 +144,10 @@ router.post('/sync', async (req, res) => {
     }
 
     console.log(`🔄 Syncing ${offers.length} offers for user ${userId} (${bank} - ${cardName})`);
-    const { syncedCount, skippedCount } = await writeOffersToDB(offers, { userId, bank, cardName });
-    console.log(`✅ Sync complete: ${syncedCount} synced, ${skippedCount} skipped`);
+    const { newCount, updatedCount, errorCount } = await writeOffersToDB(offers, { userId, bank, cardName });
+    console.log(`✅ Sync complete: ${newCount} new, ${updatedCount} updated, ${errorCount} errors`);
 
-    res.json({ success: true, synced: syncedCount, skipped: skippedCount, total: offers.length });
+    res.json({ success: true, newCount, updatedCount, errorCount, total: offers.length });
   } catch (error) {
     console.error('❌ Offers sync error:', error);
     res.status(500).json({ error: 'Failed to sync offers' });
@@ -174,18 +187,19 @@ router.post('/parse', async (req, res) => {
       const resolvedPhase = phase === 'enrolled' ? 'enrolled' : 'eligible';
       console.log(`🔍 [parse:amex] phase=${resolvedPhase} cardName=${cardName}`);
       console.log(`🔍 [parse:amex] json top-level keys:`, Object.keys(json));
-      console.log(`🔍 [parse:amex] recommendedOffers present:`, !!json.recommendedOffers);
-      console.log(`🔍 [parse:amex] addedToCard present:`, !!json.addedToCard);
+
       if (json.recommendedOffers?.offersList) {
         const pages = Object.keys(json.recommendedOffers.offersList);
         const total = pages.reduce((s, p) => s + (json.recommendedOffers.offersList[p]?.length || 0), 0);
         console.log(`🔍 [parse:amex] recommendedOffers pages=${JSON.stringify(pages)} totalRaw=${total}`);
       }
-      if (json.addedToCard?.offersList) {
-        const pages = Object.keys(json.addedToCard.offersList);
-        const total = pages.reduce((s, p) => s + (json.addedToCard.offersList[p]?.length || 0), 0);
-        console.log(`🔍 [parse:amex] addedToCard pages=${JSON.stringify(pages)} totalRaw=${total}`);
+      const enrolledContainer = json.addedToCardViewAll ?? json.addedToCard;
+      if (enrolledContainer?.offersList) {
+        const pages = Object.keys(enrolledContainer.offersList);
+        const total = pages.reduce((s, p) => s + (enrolledContainer.offersList[p]?.length || 0), 0);
+        console.log(`🔍 [parse:amex] addedToCardViewAll pages=${JSON.stringify(pages)} totalRaw=${total}`);
       }
+
       offers = parseAmexOffers(json, resolvedPhase);
       console.log(`✅ [parse:amex] parsed ${offers.length} offers`);
       if (offers.length > 0) {
@@ -209,16 +223,16 @@ router.post('/parse', async (req, res) => {
 
     if (offers.length === 0) {
       console.log(`⚠️ [parse] 0 offers found for ${bank} phase=${phase} — returning empty`);
-      return res.json({ success: true, offers: [], synced: 0, bank, message: 'No offers found.' });
+      return res.json({ success: true, offers: [], newCount: 0, updatedCount: 0, errorCount: 0, bank, message: 'No offers found.' });
     }
 
     const resolvedCardName = cardName || (bank === 'chase' ? 'Chase Card' : 'Amex Card');
     console.log(`💾 [parse] writing ${offers.length} offers to DB for ${bank} — ${resolvedCardName}`);
-    const { syncedCount, skippedCount } = await writeOffersToDB(offers, { userId, bank, cardName: resolvedCardName });
+    const { newCount, updatedCount, errorCount } = await writeOffersToDB(offers, { userId, bank, cardName: resolvedCardName });
 
-    console.log(`✅ [parse] done: ${syncedCount} synced, ${skippedCount} skipped (${bank} — ${resolvedCardName})`);
+    console.log(`✅ [parse] done: ${offers.length} parsed → ${newCount} new, ${updatedCount} updated, ${errorCount} errors (${bank} — ${resolvedCardName})`);
 
-    res.json({ success: true, offers, synced: syncedCount, skipped: skippedCount, bank, cardName: resolvedCardName });
+    res.json({ success: true, offers, newCount, updatedCount, errorCount, bank, cardName: resolvedCardName });
   } catch (error) {
     console.error('❌ Offers parse error:', error);
     res.status(500).json({ error: 'Failed to parse and sync offers' });

--- a/api/routes/offers.js
+++ b/api/routes/offers.js
@@ -155,18 +155,6 @@ router.post('/parse', async (req, res) => {
       return res.status(400).json({ error: "bank must be 'chase' or 'amex'" });
     }
 
-    // DEBUG: log incoming HTML stats
-    console.log(`📥 [parse] bank=${bank} cardName=${cardName} phase=${phase} html.length=${html.length}`);
-    console.log(`📥 [parse] html snippet (first 300 chars):`, html.substring(0, 300));
-
-    // DEBUG: check if key Amex selectors are present in the HTML
-    if (bank === 'amex') {
-      console.log(`🔍 [parse:amex] listViewRow count:`, (html.match(/listViewRow/g) || []).length);
-      console.log(`🔍 [parse:amex] merchantOfferListAddButton count:`, (html.match(/merchantOfferListAddButton/g) || []).length);
-      console.log(`🔍 [parse:amex] merchantOfferSuccessIcon count:`, (html.match(/merchantOfferSuccessIcon/g) || []).length);
-      console.log(`🔍 [parse:amex] listViewContainer present:`, html.includes('listViewContainer'));
-    }
-
     const parseFn = bank === 'chase' ? parseChaseOffers : parseAmexOffers;
     const offers = parseFn(html);
 
@@ -175,12 +163,6 @@ router.post('/parse', async (req, res) => {
     if (bank === 'amex' && phase) {
       const activated = phase === 'enrolled';
       offers.forEach(o => { o.isActivated = activated; });
-      console.log(`🔍 [parse:amex] overriding isActivated=${activated} for all ${offers.length} offers (phase=${phase})`);
-    }
-
-    console.log(`🔍 [parse] parsed ${offers.length} offers from ${bank} HTML for user ${userId}`);
-    if (offers.length > 0) {
-      console.log(`🔍 [parse] first offer sample:`, JSON.stringify(offers[0]));
     }
 
     if (offers.length === 0) {
@@ -190,7 +172,7 @@ router.post('/parse', async (req, res) => {
     const resolvedCardName = cardName || (bank === 'chase' ? 'Chase Card' : 'Amex Card');
     const { syncedCount, skippedCount } = await writeOffersToDB(offers, { userId, bank, cardName: resolvedCardName });
 
-    console.log(`✅ [parse] Parse+sync complete: ${syncedCount} synced, ${skippedCount} skipped (${bank} — ${resolvedCardName})`);
+    console.log(`✅ [parse] ${bank} — ${resolvedCardName} — ${syncedCount} synced (phase=${phase})`);
 
     res.json({ success: true, offers, synced: syncedCount, skipped: skippedCount, bank, cardName: resolvedCardName });
   } catch (error) {

--- a/api/routes/offers.js
+++ b/api/routes/offers.js
@@ -183,7 +183,6 @@ router.post('/parse', async (req, res) => {
     const { newCount, updatedCount, errorCount } = await writeOffersToDB(offers, { userId, bank, cardName: resolvedCardName, phase: resolvedPhase });
 
     console.log(`✅ [parse] ${bank} — ${resolvedCardName} (${resolvedPhase}): ${offers.length} total, ${newCount} new, ${updatedCount} updated`);
-    console.log(`   [${resolvedPhase}] merchants: ${offers.map(o => o.merchantName).join(', ')}`);
 
     res.json({ success: true, synced: offers.length, newCount, updatedCount, errorCount, bank, cardName: resolvedCardName });
   } catch (error) {

--- a/api/routes/offers.js
+++ b/api/routes/offers.js
@@ -45,7 +45,6 @@ async function verifyToken(req, res) {
 async function writeOffersToDB(offers, { userId, bank, cardName }) {
   const userOffersRef = db.collection('users').doc(userId).collection('offers');
 
-  // Fetch all existing offer IDs for this card in one read
   const existingSnap = await userOffersRef
     .where('bank', '==', bank)
     .where('cardName', '==', cardName)
@@ -124,9 +123,8 @@ router.post('/sync', async (req, res) => {
       return res.status(400).json({ error: 'bank and cardName are required' });
     }
 
-    console.log(`🔄 Syncing ${offers.length} offers for user ${userId} (${bank} - ${cardName})`);
     const { newCount, updatedCount, errorCount } = await writeOffersToDB(offers, { userId, bank, cardName });
-    console.log(`✅ Sync complete: ${newCount} new, ${updatedCount} updated, ${errorCount} errors`);
+    console.log(`✅ [sync] done: ${offers.length} parsed → ${newCount} new, ${updatedCount} updated, ${errorCount} errors (${bank} — ${cardName})`);
 
     res.json({ success: true, newCount, updatedCount, errorCount, total: offers.length });
   } catch (error) {
@@ -149,43 +147,20 @@ router.post('/parse', async (req, res) => {
     const userId = decoded.uid;
     const { bank, cardName, phase } = req.body;
 
-    console.log(`📥 [parse] bank=${bank} phase=${phase} cardName=${cardName} userId=${userId}`);
-    console.log(`📥 [parse] body keys:`, Object.keys(req.body));
-
     if (!bank || !['chase', 'amex'].includes(bank)) {
       return res.status(400).json({ error: "bank must be 'chase' or 'amex'" });
     }
 
     let offers;
 
-    // ── Amex: JSON path ──────────────────────────────────────────
+    // ── Amex: JSON path ────────────────────────────────────────────
     if (bank === 'amex') {
       const { json } = req.body;
       if (!json || typeof json !== 'object') {
-        console.error('❌ [parse:amex] json field missing or not an object. typeof json:', typeof json);
         return res.status(400).json({ error: 'json (object) is required for amex' });
       }
       const resolvedPhase = phase === 'enrolled' ? 'enrolled' : 'eligible';
-      console.log(`🔍 [parse:amex] phase=${resolvedPhase} cardName=${cardName}`);
-      console.log(`🔍 [parse:amex] json top-level keys:`, Object.keys(json));
-
-      if (json.recommendedOffers?.offersList) {
-        const pages = Object.keys(json.recommendedOffers.offersList);
-        const total = pages.reduce((s, p) => s + (json.recommendedOffers.offersList[p]?.length || 0), 0);
-        console.log(`🔍 [parse:amex] recommendedOffers pages=${JSON.stringify(pages)} totalRaw=${total}`);
-      }
-      const enrolledContainer = json.addedToCardViewAll ?? json.addedToCard;
-      if (enrolledContainer?.offersList) {
-        const pages = Object.keys(enrolledContainer.offersList);
-        const total = pages.reduce((s, p) => s + (enrolledContainer.offersList[p]?.length || 0), 0);
-        console.log(`🔍 [parse:amex] addedToCardViewAll pages=${JSON.stringify(pages)} totalRaw=${total}`);
-      }
-
       offers = parseAmexOffers(json, resolvedPhase);
-      console.log(`✅ [parse:amex] parsed ${offers.length} offers`);
-      if (offers.length > 0) {
-        console.log(`✅ [parse:amex] first offer sample:`, JSON.stringify(offers[0]));
-      }
     }
 
     // ── Chase: HTML path (unchanged) ─────────────────────────────
@@ -194,21 +169,14 @@ router.post('/parse', async (req, res) => {
       if (!html || typeof html !== 'string') {
         return res.status(400).json({ error: 'html (string) is required for chase' });
       }
-      console.log(`🔍 [parse:chase] cardName=${cardName} html.length=${html.length}`);
       offers = parseChaseOffers(html);
-      console.log(`✅ [parse:chase] parsed ${offers.length} offers`);
-      if (offers.length > 0) {
-        console.log(`✅ [parse:chase] first offer sample:`, JSON.stringify(offers[0]));
-      }
     }
 
     if (offers.length === 0) {
-      console.log(`⚠️ [parse] 0 offers found for ${bank} phase=${phase} — returning empty`);
       return res.json({ success: true, offers: [], newCount: 0, updatedCount: 0, errorCount: 0, bank, message: 'No offers found.' });
     }
 
     const resolvedCardName = cardName || (bank === 'chase' ? 'Chase Card' : 'Amex Card');
-    console.log(`💾 [parse] writing ${offers.length} offers to DB for ${bank} — ${resolvedCardName}`);
     const { newCount, updatedCount, errorCount } = await writeOffersToDB(offers, { userId, bank, cardName: resolvedCardName });
 
     console.log(`✅ [parse] done: ${offers.length} parsed → ${newCount} new, ${updatedCount} updated, ${errorCount} errors (${bank} — ${resolvedCardName})`);

--- a/api/routes/offers.js
+++ b/api/routes/offers.js
@@ -1,7 +1,11 @@
 // ─────────────────────────────────────────────
 // OFFERS ROUTES
 // POST /api/offers/sync  — sync pre-parsed offers from Chrome extension
-// POST /api/offers/parse — parse raw HTML from mobile WebView + sync
+// POST /api/offers/parse — parse raw data from mobile WebView + sync
+//
+// Parse payload by bank:
+//   Chase → { html: string,  bank: 'chase', cardName, phase? }
+//   Amex  → { json: object,  bank: 'amex',  cardName, phase: 'eligible'|'enrolled' }
 //
 // Storage: /users/{userId}/offers/{offerId}  (subcollection per user)
 // Cleanup: expired offers are purged on every sync (no Firestore TTL needed)
@@ -11,7 +15,7 @@ import { db, auth } from '../config/firebase.js';
 import { FieldValue, Timestamp } from 'firebase-admin/firestore';
 import { generateOfferId, normalizeMerchant } from '../lib/shared/offerUtils.js';
 import { parseChaseOffers } from '../lib/parsers/chase.js';
-import { parseAmexOffers } from '../lib/parsers/amex.js';
+import { parseAmexOffers }  from '../lib/parsers/amex.js';
 
 const router = express.Router();
 
@@ -139,6 +143,9 @@ router.post('/sync', async (req, res) => {
 
 /**
  * POST /api/offers/parse
+ *
+ * Chase: expects { html: string, bank: 'chase', cardName, phase? }
+ * Amex:  expects { json: object, bank: 'amex',  cardName, phase: 'eligible'|'enrolled' }
  */
 router.post('/parse', async (req, res) => {
   try {
@@ -146,33 +153,45 @@ router.post('/parse', async (req, res) => {
     if (!decoded) return;
 
     const userId = decoded.uid;
-    const { html, bank, cardName, phase } = req.body;
+    const { bank, cardName, phase } = req.body;
 
-    if (!html || typeof html !== 'string') {
-      return res.status(400).json({ error: 'html is required and must be a string' });
-    }
     if (!bank || !['chase', 'amex'].includes(bank)) {
       return res.status(400).json({ error: "bank must be 'chase' or 'amex'" });
     }
 
-    const parseFn = bank === 'chase' ? parseChaseOffers : parseAmexOffers;
-    const offers = parseFn(html);
+    let offers;
 
-    // For Amex, override isActivated based on phase:
-    // eligible page = all not activated, enrolled page = all activated
-    if (bank === 'amex' && phase) {
-      const activated = phase === 'enrolled';
-      offers.forEach(o => { o.isActivated = activated; });
+    // ── Amex: JSON path ──────────────────────────────────────────
+    if (bank === 'amex') {
+      const { json } = req.body;
+      if (!json || typeof json !== 'object') {
+        return res.status(400).json({ error: 'json (object) is required for amex' });
+      }
+      const resolvedPhase = phase === 'enrolled' ? 'enrolled' : 'eligible';
+      console.log(`📥 [parse:amex] phase=${resolvedPhase} cardName=${cardName}`);
+      offers = parseAmexOffers(json, resolvedPhase);
+      console.log(`🔍 [parse:amex] parsed ${offers.length} offers`);
+    }
+
+    // ── Chase: HTML path (unchanged) ─────────────────────────────
+    else {
+      const { html } = req.body;
+      if (!html || typeof html !== 'string') {
+        return res.status(400).json({ error: 'html (string) is required for chase' });
+      }
+      console.log(`📥 [parse:chase] cardName=${cardName} html.length=${html.length}`);
+      offers = parseChaseOffers(html);
+      console.log(`🔍 [parse:chase] parsed ${offers.length} offers`);
     }
 
     if (offers.length === 0) {
-      return res.json({ success: true, offers: [], synced: 0, bank, message: 'No offers found in provided HTML.' });
+      return res.json({ success: true, offers: [], synced: 0, bank, message: 'No offers found.' });
     }
 
     const resolvedCardName = cardName || (bank === 'chase' ? 'Chase Card' : 'Amex Card');
     const { syncedCount, skippedCount } = await writeOffersToDB(offers, { userId, bank, cardName: resolvedCardName });
 
-    console.log(`✅ [parse] ${bank} — ${resolvedCardName} — ${syncedCount} synced (phase=${phase})`);
+    console.log(`✅ [parse] ${bank} parse+sync complete: ${syncedCount} synced, ${skippedCount} skipped (${resolvedCardName})`);
 
     res.json({ success: true, offers, synced: syncedCount, skipped: skippedCount, bank, cardName: resolvedCardName });
   } catch (error) {

--- a/mobile/components/SyncWebView.js
+++ b/mobile/components/SyncWebView.js
@@ -60,7 +60,7 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
   const [syncStarted, setSyncStarted]       = useState(false);
   const [pageLoaded, setPageLoaded]         = useState(false);
   const [onOffersPage, setOnOffersPage]     = useState(false);
-  const [amexCardsReady, setAmexCardsReady] = useState(false); // true only after AMEX_CARDS_DETECTED fires with cards
+  const [amexCardsReady, setAmexCardsReady] = useState(false);
   const [currentCard, setCurrentCard]       = useState(null);
   const [currentUrl, setCurrentUrl]         = useState('');
   const [cardCount, setCardCount]           = useState(0);
@@ -98,13 +98,11 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
   }, [visible]);
 
   // ── Amex: switch to next unvisited card ──────────────────────────
-  // Returns true if a switch was initiated, false if all cards visited.
   const switchToNextAmexCard = () => {
     const cards   = cardOptionsRef.current;
     const visited = visitedCardsRef.current;
-    // Find next unvisited card — initial active card is saved for last
     const next = cards.find(c => !visited.has(c.testId) && c.testId !== initialActiveRef.current)
-      ?? cards.find(c => !visited.has(c.testId)); // fallback: initial active card (last)
+      ?? cards.find(c => !visited.has(c.testId));
     if (!next) {
       console.log('[SyncWebView:amex] all cards visited for phase', syncPhaseRef.current);
       return false;
@@ -154,7 +152,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         injectJavaScript: (js) => webViewRef.current?.injectJavaScript(js),
       });
       setOnOffersPage(onOffers);
-      // Reset cards-ready on each new page load so button re-gates until detection completes
       if (onOffers) {
         setAmexCardsReady(false);
         console.log(`[SyncWebView:amex] arming JSON interceptor on loadEnd (phase=${syncPhaseRef.current})`);
@@ -181,7 +178,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         Alert.alert('No cards found', 'Please wait for the page to fully load.');
         return;
       }
-      // Save the currently active card — it will be captured last
       const activeCard = cards.find(c => c.selected) ?? cards[0];
       initialActiveRef.current = activeCard.testId;
       console.log(`[SyncWebView:amex] sync start — active card: ${activeCard.label} (will capture last)`);
@@ -189,7 +185,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       return;
     }
 
-    // Chase
     captureArmed.current = true;
     webViewRef.current?.injectJavaScript(buildCaptureJs(config.gridSelector, config.captureMaxBytes));
   };
@@ -228,19 +223,16 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
     setSyncing(false);
 
     if (bank === 'amex') {
-      // Mark this card as visited
       if (capturedTestId) visitedCardsRef.current.add(capturedTestId);
       const totalCards = cardOptionsRef.current.length;
       const visited    = visitedCardsRef.current.size;
       console.log(`[SyncWebView:amex] visited=${visited}/${totalCards} phase=${phase}`);
 
       if (visited < totalCards) {
-        // More cards to capture in this phase
         switchToNextAmexCard();
         return;
       }
 
-      // All cards done for this phase
       if (phase === 'eligible') {
         console.log('[SyncWebView:amex] eligible phase complete — transitioning to enrolled');
         visitedCardsRef.current  = new Set();
@@ -252,7 +244,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         return;
       }
 
-      // enrolled phase complete — all done
       const total = syncedCardsRef.current.reduce((sum, c) => sum + c.count, 0);
       console.log(`[SyncWebView:amex] all phases complete — total offers synced: ${total}`);
       onSuccess(total, syncedCardsRef.current);
@@ -260,7 +251,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       return;
     }
 
-    // Chase multi-card
     syncedCountRef.current += 1;
     const totalCards = cardOptionsRef.current.length;
     if (syncedCountRef.current < totalCards) {
@@ -284,7 +274,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       const data = JSON.parse(event.nativeEvent.data);
       console.log(`[SyncWebView:${bank}] ✉️ message type=${data.type}`, data.error ? `error=${data.error}` : '');
 
-      // ── Chase card detection ──────────────────────────
       if (data.type === 'CARDS_DETECTED') {
         const hasCards = data.cards?.length > 0;
         console.log(`[SyncWebView:chase] CARDS_DETECTED count=${data.cards?.length} selected=${data.selectedLabel}`);
@@ -301,12 +290,10 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         return;
       }
 
-      // ── Amex card detection ───────────────────────────
       if (data.type === 'AMEX_CARDS_DETECTED') {
         const hasCards = data.cards?.length > 0;
         console.log(`[SyncWebView:amex] AMEX_CARDS_DETECTED count=${data.cards?.length} phase=${syncPhaseRef.current} alreadyDiscovered=${cardsDiscovered.current}`);
         if (!cardsDiscovered.current && hasCards && cardOptionsRef.current.length === 0) {
-          // Only store cards once (eligible phase) — reuse for enrolled
           cardOptionsRef.current = data.cards;
           setCardCount(data.cards.length);
           const activeIdx = data.cards.findIndex(c => c.selected);
@@ -316,10 +303,8 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         }
         if (!cardsDiscovered.current) cardsDiscovered.current = true;
         setCurrentCard(data.selectedLabel || null);
-        // Mark cards ready — Sync button will now be enabled
         if (hasCards) setAmexCardsReady(true);
 
-        // Enrolled phase: cards already known, start switching immediately
         if (syncPhaseRef.current === 'enrolled' && syncStarted) {
           console.log('[SyncWebView:amex] enrolled page ready — starting card cycle');
           const activeCard = data.cards?.find(c => c.selected) ?? cardOptionsRef.current[0];
@@ -329,16 +314,13 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         return;
       }
 
-      // ── Card switched ─────────────────────────────────────
       if (data.type === 'CARD_SWITCHED') {
         console.log(`[SyncWebView:${bank}] CARD_SWITCHED cardLabel=${data.cardLabel}`);
         setSwitching(false);
         setCurrentCard(data.cardLabel || null);
         if (bank === 'amex') {
-          // CAPTURE_JSON already fired before this — just update label for next use
           pendingCardLabelRef.current = data.cardLabel || null;
         } else {
-          // Chase: capture after delay
           console.log(`[SyncWebView:chase] switch confirmed — capturing in ${POST_SWITCH_DELAY_MS}ms`);
           setTimeout(() => {
             captureArmed.current = true;
@@ -372,7 +354,15 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         }
         captureArmed.current = false;
 
-        // Find the testId of the card that just fired the API
+        // ── DEBUG: log raw offersList as received from WebView ──
+        const offersList = data.json?.recommendedOffers?.offersList;
+        if (offersList) {
+          console.log('[SyncWebView:amex] DEBUG recommendedOffers.offersList:', JSON.stringify(offersList));
+        } else {
+          console.log('[SyncWebView:amex] DEBUG recommendedOffers.offersList: missing');
+        }
+        // ───────────────────────────────────────────────────────
+
         const cards = cardOptionsRef.current;
         const capturedCard = cards.find(c =>
           data.cardLabel && (c.label + (c.last4 ? ` (...${c.last4})` : '')) === data.cardLabel
@@ -433,7 +423,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       );
     }
     if (onOffersPage) {
-      // For Amex: wait for card detection before enabling Sync button
       const ready = pageLoaded && (bank === 'amex' ? amexCardsReady : true);
       return (
         <TouchableOpacity

--- a/mobile/components/SyncWebView.js
+++ b/mobile/components/SyncWebView.js
@@ -4,17 +4,22 @@
 // Bank-specific JS injection is in sync/ modules.
 //
 // Footer states:
-//   0. Not ready         → nothing
-//   1. On offers page    → "Sync Offers" button
-//   2. Page loaded, not on offers page → "Go to Offers Page"
-//   3. Sync in progress  → spinner + status
+//   0. Not ready                        → nothing
+//   1. On offers page + page loaded     → "Sync Offers" button (enabled)
+//   2. Page loaded, not on offers page  → "Go to Offers Page"
+//   3. Sync in progress                 → spinner + status
 //
 // onOffersPage source of truth per bank:
 //   Chase → CARDS_DETECTED message (SPA)
-//   Amex  → handleLoadEnd URL check
-//          navState fires AFTER loadEnd on Amex and would reset
-//          onOffersPage back to false — so we skip the reset for Amex only
+//   Amex  → handleLoadEnd URL check via amexHandleLoadEnd()
+//           navState fires AFTER loadEnd on Amex so we skip the reset for Amex
 //   Other → handleNavigationStateChange URL check
+//
+// Amex two-phase sync:
+//   Phase 1 (eligible) — user taps "Sync Offers"
+//   Phase 2 (enrolled) — auto after all eligible cards done
+//   Both phases use the same per-card switching + capture pipeline.
+//   incognito={true} ensures clean session every time.
 //
 // Adding a new bank:
 //   1. Add entry to sync/bankConfig.js
@@ -32,7 +37,7 @@ import { colors, radii } from '../shared/theme.js';
 
 import { BANK_CONFIG }                                    from './sync/bankConfig.js';
 import { DETECT_CARDS_JS, buildSwitchCardJs }             from './sync/chaseSync.js';
-import { AMEX_OPEN_AND_DETECT_JS, buildAmexSwitchCardJs } from './sync/amexSync.js';
+import { AMEX_OPEN_AND_DETECT_JS, buildAmexSwitchCardJs, amexHandleLoadEnd } from './sync/amexSync.js';
 import { buildCaptureJs, parseCardLabel }                 from './sync/captureJs.js';
 
 const API_BASE_URL         = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3001';
@@ -43,15 +48,19 @@ const MAX_SWITCH_RETRIES   = 3;
 export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
   const webViewRef = useRef(null);
 
+  // ── Sync state refs (not UI) ──────────────────────────────────
   const cardOptionsRef   = useRef([]);
   const cardIndexRef     = useRef(0);
   const syncedCardsRef   = useRef([]);
   const cardsDiscovered  = useRef(false);
   const switchRetriesRef = useRef(0);
-  const syncedCountRef   = useRef(0);
+  const syncedCountRef   = useRef(0);   // cards synced in current phase
   const captureArmed     = useRef(false);
   const autoCapturing    = useRef(false);
+  // Amex two-phase: 'eligible' | 'enrolled'
+  const syncPhaseRef     = useRef('eligible');
 
+  // ── UI state ──────────────────────────────────────────────────
   const [syncing, setSyncing]           = useState(false);
   const [switching, setSwitching]       = useState(false);
   const [syncStarted, setSyncStarted]   = useState(false);
@@ -61,9 +70,12 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
   const [currentUrl, setCurrentUrl]     = useState('');
   const [cardCount, setCardCount]       = useState(0);
   const [cardIndexUi, setCardIndexUi]   = useState(0);
+  // Amex phase label for status text
+  const [syncPhaseUi, setSyncPhaseUi]   = useState('eligible');
 
   const config = BANK_CONFIG[bank] || BANK_CONFIG.chase;
 
+  // ── Reset on close ────────────────────────────────────────────
   useEffect(() => {
     if (!visible) {
       cardOptionsRef.current   = [];
@@ -74,6 +86,7 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       syncedCountRef.current   = 0;
       captureArmed.current     = false;
       autoCapturing.current    = false;
+      syncPhaseRef.current     = 'eligible';
       setCurrentCard(null);
       setCurrentUrl('');
       setSyncing(false);
@@ -83,8 +96,30 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       setOnOffersPage(false);
       setCardCount(0);
       setCardIndexUi(0);
+      setSyncPhaseUi('eligible');
     }
   }, [visible]);
+
+  // ── Helpers ───────────────────────────────────────────────────
+
+  // Reset per-card state when transitioning to a new sync phase.
+  // Called before navigating to enrolled page.
+  const resetForPhase = (phase) => {
+    cardIndexRef.current     = 0;
+    syncedCountRef.current   = 0;
+    cardsDiscovered.current  = false;
+    switchRetriesRef.current = 0;
+    captureArmed.current     = false;
+    autoCapturing.current    = false;
+    syncPhaseRef.current     = phase;
+    setSyncPhaseUi(phase);
+    setCardIndexUi(0);
+    setSwitching(false);
+    setSyncing(false);
+    // Keep cardOptionsRef — same cards, same order, just restart index
+  };
+
+  // ── Navigation handlers ───────────────────────────────────────
 
   const handleNavigationStateChange = (navState) => {
     if (!navState.url) return;
@@ -115,15 +150,24 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
     }
 
     if (bank === 'amex') {
-      const onLogin  = (config.loginPaths  || []).some(p => url.includes(p.toLowerCase()));
-      const onOffers = !onLogin && (config.offersPaths || []).some(p => url.includes(p.toLowerCase()));
-      console.log(`[SyncWebView:amex] onLogin=${onLogin} onOffers=${onOffers} cardsDiscovered=${cardsDiscovered.current}`);
+      const { onOffersPage: onOffers, detectedPhase } = amexHandleLoadEnd({
+        url,
+        config,
+        syncPhase:       syncPhaseRef.current,
+        cardsDiscovered: cardsDiscovered.current,
+        injectJavaScript: (js) => webViewRef.current?.injectJavaScript(js),
+      });
       setOnOffersPage(onOffers);
-      if (onOffers && !cardsDiscovered.current) {
-        console.log('[SyncWebView:amex] injecting AMEX_OPEN_AND_DETECT_JS');
-        webViewRef.current?.injectJavaScript(AMEX_OPEN_AND_DETECT_JS);
+
+      // If we auto-navigated to enrolled and it loaded, arm auto-capture
+      // for first card (cards already known, index already reset to 0)
+      if (detectedPhase === 'enrolled' && syncPhaseRef.current === 'enrolled' && onOffers) {
+        console.log('[SyncWebView:amex] enrolled page loaded — will auto-capture after card detection');
       }
+      return;
     }
+
+    // Future banks: URL-based detection
   };
 
   const handleGoToOffers = () => {
@@ -132,6 +176,7 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
     webViewRef.current?.injectJavaScript(`window.location.replace('${target}'); true;`);
   };
 
+  // ── User taps "Sync Offers" (eligible phase only) ─────────────
   const handleSyncPress = () => {
     console.log(`[SyncWebView:${bank}] Sync pressed — gridSelector:`, config.gridSelector, 'captureMaxBytes:', config.captureMaxBytes);
     setSyncStarted(true);
@@ -139,12 +184,28 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
     webViewRef.current?.injectJavaScript(buildCaptureJs(config.gridSelector, config.captureMaxBytes));
   };
 
+  // ── Transition from eligible → enrolled (Amex only) ──────────
+  const transitionToEnrolled = () => {
+    console.log('[SyncWebView:amex] transitioning to enrolled phase');
+    resetForPhase('enrolled');
+    // Navigate to enrolled URL — handleLoadEnd will detect it and inject card detection
+    webViewRef.current?.injectJavaScript(`window.location.replace('${config.enrolledUrl}'); true;`);
+  };
+
+  // ── After card detection in enrolled phase — auto-capture ─────
+  const autoCapureEnrolledCard = () => {
+    console.log('[SyncWebView:amex] auto-capturing enrolled card at index', cardIndexRef.current);
+    captureArmed.current = true;
+    webViewRef.current?.injectJavaScript(buildCaptureJs(config.gridSelector, config.captureMaxBytes));
+  };
+
+  // ── Message handler ───────────────────────────────────────────
   const handleMessage = async (event) => {
     try {
       const data = JSON.parse(event.nativeEvent.data);
       console.log(`[SyncWebView:${bank}] message type:`, data.type, data.error || '');
 
-      // ── Chase card detection ────────────────────────────
+      // ── Chase card detection ──────────────────────────────────
       if (data.type === 'CARDS_DETECTED') {
         const hasCards = data.cards?.length > 0;
         if (!cardsDiscovered.current && hasCards) {
@@ -160,23 +221,44 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         return;
       }
 
-      // ── Amex card detection ────────────────────────────
+      // ── Amex card detection ───────────────────────────────────
       if (data.type === 'AMEX_CARDS_DETECTED') {
-        console.log('[SyncWebView:amex] AMEX_CARDS_DETECTED cards:', data.cards?.length, 'error:', data.error);
+        console.log('[SyncWebView:amex] AMEX_CARDS_DETECTED cards:', data.cards?.length, 'phase:', syncPhaseRef.current, 'error:', data.error);
         const hasCards = data.cards?.length > 0;
+
         if (!cardsDiscovered.current && hasCards) {
-          cardOptionsRef.current  = data.cards;
+          // For eligible phase: store cards (source of truth for card list)
+          // For enrolled phase: cards are already in cardOptionsRef, just mark discovered
+          if (syncPhaseRef.current === 'eligible') {
+            cardOptionsRef.current = data.cards;
+            setCardCount(data.cards.length);
+            const activeIdx = data.cards.findIndex(c => c.selected);
+            cardIndexRef.current = activeIdx >= 0 ? activeIdx : 0;
+            setCardIndexUi(cardIndexRef.current);
+          } else {
+            // enrolled: find the matching card in our stored list to keep testId consistency
+            // index already reset to 0 in resetForPhase
+            setCardIndexUi(0);
+          }
           cardsDiscovered.current = true;
-          setCardCount(data.cards.length);
-          const activeIdx = data.cards.findIndex(c => c.selected);
-          cardIndexRef.current = activeIdx >= 0 ? activeIdx : 0;
-          setCardIndexUi(cardIndexRef.current);
           setCurrentCard(data.selectedLabel || null);
+
+          // enrolled phase: auto-capture the first card immediately
+          if (syncPhaseRef.current === 'enrolled') {
+            console.log('[SyncWebView:amex] enrolled cards detected — switching to card 0 first');
+            const firstCard = cardOptionsRef.current[0];
+            if (firstCard) {
+              setSwitching(true);
+              webViewRef.current?.injectJavaScript(buildAmexSwitchCardJs(firstCard.testId, SWITCH_TIMEOUT_MS));
+            } else {
+              autoCapureEnrolledCard();
+            }
+          }
         }
         return;
       }
 
-      // ── Card switched (Chase + Amex) ──────────────────────
+      // ── Card switched (Chase + Amex) ──────────────────────────
       if (data.type === 'CARD_SWITCHED') {
         let switchConfirmed = false;
         if (bank === 'amex') {
@@ -203,6 +285,15 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         switchRetriesRef.current = 0;
         setSwitching(false);
         setCurrentCard(data.cardLabel || null);
+
+        // For enrolled phase, capture immediately after switch (no extra delay needed
+        // since switch already waits SWITCH_TIMEOUT_MS)
+        if (syncPhaseRef.current === 'enrolled') {
+          autoCapureEnrolledCard();
+          return;
+        }
+
+        // Eligible phase: original delay before capture
         autoCapturing.current = true;
         setTimeout(() => {
           captureArmed.current  = true;
@@ -231,7 +322,7 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       }
       captureArmed.current = false;
 
-      console.log(`[SyncWebView:${bank}] CAPTURE_HTML received — html.length=${data.html?.length} cardLabel=${data.cardLabel}`);
+      console.log(`[SyncWebView:${bank}] CAPTURE_HTML received — html.length=${data.html?.length} cardLabel=${data.cardLabel} phase=${syncPhaseRef.current}`);
 
       setSyncing(true);
       const user = getAuthInstance().currentUser;
@@ -243,7 +334,7 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         ? (cardLast4 ? `${cardName} (...${cardLast4})` : cardName)
         : null;
 
-      console.log(`[SyncWebView:${bank}] POSTing to ${API_BASE_URL}/api/offers/parse — bank=${bank} cardName=${fullCardName}`);
+      console.log(`[SyncWebView:${bank}] POSTing — bank=${bank} cardName=${fullCardName} phase=${syncPhaseRef.current}`);
 
       const response = await fetch(`${API_BASE_URL}/api/offers/parse`, {
         method: 'POST',
@@ -256,14 +347,16 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
 
       syncedCardsRef.current = [
         ...syncedCardsRef.current,
-        { cardName: fullCardName || 'Unknown Card', count: result.synced ?? 0 },
+        { cardName: fullCardName || 'Unknown Card', count: result.synced ?? 0, phase: syncPhaseRef.current },
       ];
       syncedCountRef.current += 1;
 
-      const totalCards = cardOptionsRef.current.length;
+      const totalCards   = cardOptionsRef.current.length;
+      const currentPhase = syncPhaseRef.current;
       setSyncing(false);
 
       if (syncedCountRef.current < totalCards) {
+        // More cards to sync in this phase
         const nextPos = (cardIndexRef.current + 1) % totalCards;
         cardIndexRef.current = nextPos;
         setCardIndexUi(nextPos);
@@ -275,7 +368,11 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         } else {
           webViewRef.current?.injectJavaScript(buildSwitchCardJs(cardOptionsRef.current[nextPos].index, SWITCH_TIMEOUT_MS));
         }
+      } else if (bank === 'amex' && currentPhase === 'eligible') {
+        // All eligible cards done — transition to enrolled phase
+        transitionToEnrolled();
       } else {
+        // All done (enrolled phase complete, or non-Amex bank)
         const total = syncedCardsRef.current.reduce((sum, c) => sum + c.count, 0);
         onSuccess(total, syncedCardsRef.current);
         onClose();
@@ -290,13 +387,19 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
     }
   };
 
+  // ── Render ────────────────────────────────────────────────────
   const { cardName } = parseCardLabel(currentCard);
   const totalCards   = cardCount || 1;
-  const statusText   = switching
-    ? `⏳ Switching to card ${cardIndexUi + 1} of ${totalCards}...`
-    : syncing
-      ? `🔄 Syncing ${cardName || 'card'} (${cardIndexUi + 1} of ${totalCards})...`
-      : `⚡ Processing...`;
+
+  const phaseLabel = syncPhaseUi === 'enrolled' ? 'activated' : 'eligible';
+
+  const statusText = switching && syncPhaseRef.current === 'enrolled' && syncedCountRef.current === 0 && cardIndexRef.current === 0
+    ? `⏳ Switching to activated offers...`
+    : switching
+      ? `⏳ Switching to card ${cardIndexUi + 1} of ${totalCards}...`
+      : syncing
+        ? `🔄 Syncing ${phaseLabel} offers — ${cardName || 'card'} (${cardIndexUi + 1} of ${totalCards})...`
+        : `⚡ Processing...`;
 
   const renderFooter = () => {
     if (syncStarted) {
@@ -308,9 +411,15 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       );
     }
     if (onOffersPage) {
+      // Button only enabled when page is fully loaded
+      const ready = pageLoaded;
       return (
-        <TouchableOpacity style={s.syncBtn} onPress={handleSyncPress}>
-          <Text style={s.syncBtnText}>Sync Offers</Text>
+        <TouchableOpacity
+          style={[s.syncBtn, !ready && s.syncBtnDisabled]}
+          onPress={ready ? handleSyncPress : undefined}
+          disabled={!ready}
+        >
+          <Text style={s.syncBtnText}>{ready ? 'Sync Offers' : 'Loading...'}</Text>
         </TouchableOpacity>
       );
     }
@@ -344,8 +453,8 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
             onNavigationStateChange={handleNavigationStateChange}
             onLoadEnd={handleLoadEnd}
             style={s.webview}
-            incognito={false}
-            sharedCookiesEnabled={true}
+            incognito={true}
+            sharedCookiesEnabled={false}
             thirdPartyCookiesEnabled={true}
           />
           <View style={s.footer}>
@@ -358,20 +467,21 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
 }
 
 const s = StyleSheet.create({
-  overlay:       { flex: 1, justifyContent: 'flex-end', backgroundColor: 'rgba(0,0,0,0.45)' },
-  sheet:         { height: '87%', backgroundColor: 'white', borderTopLeftRadius: 20, borderTopRightRadius: 20, overflow: 'hidden' },
-  handle:        { width: 40, height: 4, backgroundColor: colors.border, borderRadius: radii.full, alignSelf: 'center', marginTop: 10, marginBottom: 4 },
-  header:        { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', paddingHorizontal: 16, paddingVertical: 12, borderBottomWidth: 1, borderBottomColor: colors.border },
-  closeBtn:      { width: 36, height: 36, borderRadius: 18, backgroundColor: colors.disabledBg, alignItems: 'center', justifyContent: 'center' },
-  closeBtnText:  { fontSize: 14, color: colors.textSecondary, fontWeight: '600' },
-  headerTitle:   { fontSize: 16, fontWeight: '700', color: colors.textPrimary },
-  webview:       { flex: 1 },
-  footer:        { minHeight: 56, padding: 16, borderTopWidth: 1, borderTopColor: colors.border, backgroundColor: 'white' },
-  hint:          { fontSize: 12, color: colors.textMuted, textAlign: 'center', marginBottom: 10 },
-  syncBtn:       { backgroundColor: colors.primary, borderRadius: radii.md, paddingVertical: 14, alignItems: 'center' },
-  goToOffersBtn: { backgroundColor: colors.primaryLight, borderRadius: radii.md, paddingVertical: 14, alignItems: 'center' },
-  syncBtnText:   { color: 'white', fontSize: 16, fontWeight: '700' },
-  statusRow:     { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', paddingVertical: 10 },
-  spinner:       { marginRight: 10 },
-  statusText:    { fontSize: 14, fontWeight: '600', color: colors.textPrimary },
+  overlay:         { flex: 1, justifyContent: 'flex-end', backgroundColor: 'rgba(0,0,0,0.45)' },
+  sheet:           { height: '87%', backgroundColor: 'white', borderTopLeftRadius: 20, borderTopRightRadius: 20, overflow: 'hidden' },
+  handle:          { width: 40, height: 4, backgroundColor: colors.border, borderRadius: radii.full, alignSelf: 'center', marginTop: 10, marginBottom: 4 },
+  header:          { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', paddingHorizontal: 16, paddingVertical: 12, borderBottomWidth: 1, borderBottomColor: colors.border },
+  closeBtn:        { width: 36, height: 36, borderRadius: 18, backgroundColor: colors.disabledBg, alignItems: 'center', justifyContent: 'center' },
+  closeBtnText:    { fontSize: 14, color: colors.textSecondary, fontWeight: '600' },
+  headerTitle:     { fontSize: 16, fontWeight: '700', color: colors.textPrimary },
+  webview:         { flex: 1 },
+  footer:          { minHeight: 56, padding: 16, borderTopWidth: 1, borderTopColor: colors.border, backgroundColor: 'white' },
+  hint:            { fontSize: 12, color: colors.textMuted, textAlign: 'center', marginBottom: 10 },
+  syncBtn:         { backgroundColor: colors.primary, borderRadius: radii.md, paddingVertical: 14, alignItems: 'center' },
+  syncBtnDisabled: { backgroundColor: colors.disabledBg },
+  goToOffersBtn:   { backgroundColor: colors.primaryLight, borderRadius: radii.md, paddingVertical: 14, alignItems: 'center' },
+  syncBtnText:     { color: 'white', fontSize: 16, fontWeight: '700' },
+  statusRow:       { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', paddingVertical: 10 },
+  spinner:         { marginRight: 10 },
+  statusText:      { fontSize: 14, fontWeight: '600', color: colors.textPrimary },
 });

--- a/mobile/components/SyncWebView.js
+++ b/mobile/components/SyncWebView.js
@@ -13,6 +13,11 @@
 //   7. All phases done → onSuccess + onClose
 //
 // Chase is completely unchanged — still uses buildCaptureJs + CAPTURE_HTML.
+//
+// Key timing note for Amex:
+//   Amex fires ReadOffersHubPresentation (REPLACE) BEFORE CARD_SWITCHED
+//   comes back from the JS timeout. So we must set window.__amexJsonCaptureArmed
+//   = true IMMEDIATELY in switchToNextAmexCard, not in the CARD_SWITCHED handler.
 // ─────────────────────────────────────────────────────────────────
 import React, { useRef, useState, useEffect } from 'react';
 import {
@@ -108,11 +113,15 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
     cardIndexRef.current = idx;
     setCardIndexUi(idx);
     setSwitching(true);
-    // Arm the capture BEFORE injecting the switch JS so the interceptor
-    // is ready when Amex fires ReadOffersHubPresentation after the switch.
+
+    // IMPORTANT: arm BOTH the RN ref AND the window flag BEFORE injecting switch JS.
+    // Amex fires ReadOffersHubPresentation (REPLACE) immediately when the card
+    // switches — well before the CARD_SWITCHED message comes back from the timeout.
+    // If we wait to arm in CARD_SWITCHED, we miss the REPLACE and get stuck.
     captureArmed.current = true;
-    // Fix 3: Clear any active filters so the full offer set is returned.
-    // Safe to call even with no filters active (no-op in that case).
+    webViewRef.current?.injectJavaScript(`window.__amexJsonCaptureArmed = true; true;`);
+
+    // Clear any active filters so the full unfiltered offer set is returned.
     webViewRef.current?.injectJavaScript(buildAmexClearFiltersJs());
     console.log(`[SyncWebView:amex] switching to card[${idx}] testId=${next.testId} (visited=${visited.size}/${cards.length})`);
     webViewRef.current?.injectJavaScript(buildAmexSwitchCardJs(next.testId, SWITCH_TIMEOUT_MS));
@@ -155,10 +164,9 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       setOnOffersPage(onOffers);
       if (onOffers) {
         setAmexCardsReady(false);
-        console.log(`[SyncWebView:amex] arming JSON interceptor on loadEnd (phase=${syncPhaseRef.current})`);
-        // NOTE: buildAmexJsonCaptureJs no longer auto-arms __amexJsonCaptureArmed.
-        // We only inject it here to install/re-install the XHR+fetch interceptors.
-        // Actual arming happens in switchToNextAmexCard via captureArmed ref.
+        console.log(`[SyncWebView:amex] (re)installing JSON interceptor on loadEnd (phase=${syncPhaseRef.current})`);
+        // Only installs/re-installs XHR+fetch interceptors — does NOT touch
+        // window.__amexJsonCaptureArmed. Arming is done in switchToNextAmexCard.
         webViewRef.current?.injectJavaScript(buildAmexJsonCaptureJs());
       }
       return;
@@ -184,8 +192,7 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       const activeCard = cards.find(c => c.selected) ?? cards[0];
       initialActiveRef.current = activeCard.testId;
       console.log(`[SyncWebView:amex] sync start — active card: ${activeCard.label} (will capture last)`);
-      // Set window.__amexJsonCaptureArmed in the WebView to match captureArmed ref
-      // (switchToNextAmexCard sets captureArmed.current = true and the interceptor reads window.__amexJsonCaptureArmed)
+      // Disarm before starting the cycle — switchToNextAmexCard will arm.
       webViewRef.current?.injectJavaScript(`window.__amexJsonCaptureArmed = false; true;`);
       switchToNextAmexCard();
       return;
@@ -313,6 +320,7 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
           console.log('[SyncWebView:amex] enrolled page ready — starting card cycle');
           const activeCard = data.cards?.find(c => c.selected) ?? cardOptionsRef.current[0];
           initialActiveRef.current = activeCard?.testId ?? null;
+          // Disarm before starting enrolled cycle — switchToNextAmexCard will arm.
           webViewRef.current?.injectJavaScript(`window.__amexJsonCaptureArmed = false; true;`);
           switchToNextAmexCard();
         }
@@ -320,14 +328,16 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       }
 
       if (data.type === 'CARD_SWITCHED') {
+        // For Amex: capture was already armed in switchToNextAmexCard before the
+        // switch JS was injected. CARD_SWITCHED just updates UI — no arming here.
         console.log(`[SyncWebView:${bank}] CARD_SWITCHED cardLabel=${data.cardLabel}`);
         setSwitching(false);
         setCurrentCard(data.cardLabel || null);
         if (bank === 'amex') {
-          // For Amex: captureArmed was set in switchToNextAmexCard.
-          // Now sync the window flag so the interceptor can fire.
           pendingCardLabelRef.current = data.cardLabel || null;
-          webViewRef.current?.injectJavaScript(`window.__amexJsonCaptureArmed = true; true;`);
+          // If CAPTURE_JSON already fired (common case), captureArmed is already
+          // false and CARD_SWITCHED is just informational. If it hasn't fired yet
+          // (slow network), window.__amexJsonCaptureArmed is still true — good.
         } else {
           console.log(`[SyncWebView:chase] switch confirmed — capturing in ${POST_SWITCH_DELAY_MS}ms`);
           setTimeout(() => {
@@ -355,7 +365,7 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         return;
       }
 
-      // ── DEBUG_DUMP: log every Amex API call to disk (fired by amexSync.js for ALL calls) ──
+      // ── DEBUG_DUMP: log every Amex API call to disk ──
       if (data.type === 'DEBUG_DUMP' && bank === 'amex') {
         console.log(`[SyncWebView:amex] DEBUG_DUMP label=${data.label}`);
         fetch(`${API_BASE_URL}/api/debug/dump`, {

--- a/mobile/components/SyncWebView.js
+++ b/mobile/components/SyncWebView.js
@@ -1,6 +1,18 @@
 // ─────────────────────────────────────────────────────────────────
 // SYNC WEBVIEW MODAL — orchestrator
 // Handles modal UI, state, and message routing.
+//
+// Amex sync flow:
+//   1. User lands on offers page → AMEX_CARDS_DETECTED fires with all cards
+//   2. User taps Sync → we switch to first non-active card
+//   3. Card switch triggers ReadOffersHubPresentation API → CAPTURE_JSON
+//   4. POST to /api/offers/parse → write to DB
+//   5. Switch to next unvisited card → repeat until all cards captured
+//      (active card on sync press is captured last)
+//   6. Transition to enrolled page → reuse same card list → repeat cycle
+//   7. All phases done → onSuccess + onClose
+//
+// Chase is completely unchanged — still uses buildCaptureJs + CAPTURE_HTML.
 // ─────────────────────────────────────────────────────────────────
 import React, { useRef, useState, useEffect } from 'react';
 import {
@@ -29,16 +41,17 @@ const MAX_SWITCH_RETRIES   = 3;
 export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
   const webViewRef = useRef(null);
 
-  // ── Sync state refs (not UI) ──────────────────────────────────
-  const cardOptionsRef      = useRef([]);
-  const cardIndexRef        = useRef(0);
+  // ── Sync state refs ─────────────────────────────────────────────
+  const cardOptionsRef      = useRef([]);   // [{label, last4, testId, index, selected}]
+  const cardIndexRef        = useRef(0);    // current card index being synced
+  const visitedCardsRef     = useRef(new Set()); // testIds already captured this phase
+  const initialActiveRef    = useRef(null); // testId of card active when Sync was pressed
   const syncedCardsRef      = useRef([]);
   const cardsDiscovered     = useRef(false);
   const switchRetriesRef    = useRef(0);
   const syncedCountRef      = useRef(0);
   const captureArmed        = useRef(false);
   const syncPhaseRef        = useRef('eligible');
-  const switchPendingRef    = useRef(null);
   const pendingCardLabelRef = useRef(null);
 
   // ── UI state ──────────────────────────────────────────────────
@@ -60,13 +73,14 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
     if (!visible) {
       cardOptionsRef.current      = [];
       cardIndexRef.current        = 0;
+      visitedCardsRef.current     = new Set();
+      initialActiveRef.current    = null;
       syncedCardsRef.current      = [];
       cardsDiscovered.current     = false;
       switchRetriesRef.current    = 0;
       syncedCountRef.current      = 0;
       captureArmed.current        = false;
       syncPhaseRef.current        = 'eligible';
-      switchPendingRef.current    = null;
       pendingCardLabelRef.current = null;
       setCurrentCard(null);
       setCurrentUrl('');
@@ -81,25 +95,29 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
     }
   }, [visible]);
 
-  // ── Helpers ───────────────────────────────────────────────────
-  const resetForPhase = (phase) => {
-    console.log(`[SyncWebView:amex] resetForPhase phase=${phase}`);
-    cardIndexRef.current        = 0;
-    syncedCountRef.current      = 0;
-    cardsDiscovered.current     = false;
-    switchRetriesRef.current    = 0;
-    captureArmed.current        = false;
-    switchPendingRef.current    = null;
-    pendingCardLabelRef.current = null;
-    syncPhaseRef.current        = phase;
-    setSyncPhaseUi(phase);
-    setCardIndexUi(0);
-    setSwitching(false);
-    setSyncing(false);
+  // ── Amex: switch to next unvisited card ──────────────────────────
+  // Returns true if a switch was initiated, false if all cards visited.
+  const switchToNextAmexCard = () => {
+    const cards   = cardOptionsRef.current;
+    const visited = visitedCardsRef.current;
+    // Find next unvisited card — initial active card is saved for last
+    const next = cards.find(c => !visited.has(c.testId) && c.testId !== initialActiveRef.current)
+      ?? cards.find(c => !visited.has(c.testId)); // fallback: initial active card (last)
+    if (!next) {
+      console.log('[SyncWebView:amex] all cards visited for phase', syncPhaseRef.current);
+      return false;
+    }
+    const idx = cards.indexOf(next);
+    cardIndexRef.current = idx;
+    setCardIndexUi(idx);
+    setSwitching(true);
+    captureArmed.current = true;
+    console.log(`[SyncWebView:amex] switching to card[${idx}] testId=${next.testId} (visited=${visited.size}/${cards.length})`);
+    webViewRef.current?.injectJavaScript(buildAmexSwitchCardJs(next.testId, SWITCH_TIMEOUT_MS));
+    return true;
   };
 
   // ── Navigation handlers ───────────────────────────────────────
-
   const handleNavigationStateChange = (navState) => {
     if (!navState.url) return;
     console.log(`[SyncWebView:${bank}] navState url:`, navState.url);
@@ -134,7 +152,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         injectJavaScript: (js) => webViewRef.current?.injectJavaScript(js),
       });
       setOnOffersPage(onOffers);
-
       if (onOffers) {
         console.log(`[SyncWebView:amex] arming JSON interceptor on loadEnd (phase=${syncPhaseRef.current})`);
         webViewRef.current?.injectJavaScript(buildAmexJsonCaptureJs());
@@ -153,37 +170,28 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
   const handleSyncPress = () => {
     console.log(`[SyncWebView:${bank}] Sync pressed — phase=${syncPhaseRef.current}`);
     setSyncStarted(true);
-    captureArmed.current = true;
 
     if (bank === 'amex') {
-      const cards      = cardOptionsRef.current;
-      const activeIdx  = cards.findIndex(c => c.selected);
-      // Switch to the first card that is NOT currently active
-      const nextIdx    = cards.findIndex((_, i) => i !== activeIdx);
-      if (nextIdx === -1) {
-        console.log('[SyncWebView:amex] only one card found — cannot switch');
-        Alert.alert('Only one card found', 'Cannot cycle cards to trigger API call.');
+      const cards = cardOptionsRef.current;
+      if (cards.length === 0) {
+        Alert.alert('No cards found', 'Please wait for the page to fully load.');
         return;
       }
-      const nextCard = cards[nextIdx];
-      cardIndexRef.current = nextIdx;
-      console.log(`[SyncWebView:amex] TEST — switching to card[${nextIdx}] testId=${nextCard.testId} to verify API fires`);
-      webViewRef.current?.injectJavaScript(buildAmexSwitchCardJs(nextCard.testId, SWITCH_TIMEOUT_MS));
+      // Save the currently active card — it will be captured last
+      const activeCard = cards.find(c => c.selected) ?? cards[0];
+      initialActiveRef.current = activeCard.testId;
+      console.log(`[SyncWebView:amex] sync start — active card: ${activeCard.label} (will capture last)`);
+      switchToNextAmexCard();
       return;
     }
 
-    // Chase (and future HTML banks)
+    // Chase
+    captureArmed.current = true;
     webViewRef.current?.injectJavaScript(buildCaptureJs(config.gridSelector, config.captureMaxBytes));
   };
 
-  const transitionToEnrolled = () => {
-    console.log('[SyncWebView:amex] transitioning to enrolled phase');
-    resetForPhase('enrolled');
-    webViewRef.current?.injectJavaScript(`window.location.replace('${config.enrolledUrl}'); true;`);
-  };
-
   // ── Shared post-capture logic ─────────────────────────────────
-  const handleCaptureResult = async ({ payload, cardLabel, phase }) => {
+  const handleCaptureResult = async ({ payload, cardLabel, phase, capturedTestId }) => {
     setSyncing(true);
     const user = getAuthInstance().currentUser;
     if (!user) throw new Error('You must be signed in to sync offers.');
@@ -199,26 +207,71 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       ? { json: payload, bank, cardName: fullCardName, phase }
       : { html: payload, bank, cardName: fullCardName, phase };
 
-    console.log(`[SyncWebView:${bank}] handleCaptureResult — phase=${phase} cardName=${fullCardName} payloadSize=${isAmex ? JSON.stringify(payload).length : payload?.length}`);
-    console.log(`[SyncWebView:${bank}] POSTing to ${API_BASE_URL}/api/offers/parse`);
-
+    console.log(`[SyncWebView:${bank}] POSTing to ${API_BASE_URL}/api/offers/parse — phase=${phase} cardName=${fullCardName}`);
     const response = await fetch(`${API_BASE_URL}/api/offers/parse`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
       body: JSON.stringify(bodyObj),
     });
     const result = await response.json();
-    console.log(`[SyncWebView:${bank}] API /parse response: synced=${result.synced} skipped=${result.skipped}`);
+    console.log(`[SyncWebView:${bank}] API response: synced=${result.synced} skipped=${result.skipped}`);
     if (!response.ok) throw new Error(result.error || 'Sync failed');
 
     syncedCardsRef.current = [
       ...syncedCardsRef.current,
       { cardName: fullCardName || 'Unknown Card', count: result.synced ?? 0, phase },
     ];
-    syncedCountRef.current += 1;
     setSyncing(false);
 
-    console.log(`[SyncWebView:${bank}] ✅ captured card — syncedCount=${syncedCountRef.current} totalCards=${cardOptionsRef.current.length} phase=${phase}`);
+    if (bank === 'amex') {
+      // Mark this card as visited
+      if (capturedTestId) visitedCardsRef.current.add(capturedTestId);
+      const totalCards = cardOptionsRef.current.length;
+      const visited    = visitedCardsRef.current.size;
+      console.log(`[SyncWebView:amex] visited=${visited}/${totalCards} phase=${phase}`);
+
+      if (visited < totalCards) {
+        // More cards to capture in this phase
+        switchToNextAmexCard();
+        return;
+      }
+
+      // All cards done for this phase
+      if (phase === 'eligible') {
+        console.log('[SyncWebView:amex] eligible phase complete — transitioning to enrolled');
+        visitedCardsRef.current  = new Set();
+        initialActiveRef.current = null;
+        syncPhaseRef.current     = 'enrolled';
+        setSyncPhaseUi('enrolled');
+        cardsDiscovered.current  = false;
+        webViewRef.current?.injectJavaScript(`window.location.replace('${config.enrolledUrl}'); true;`);
+        return;
+      }
+
+      // enrolled phase complete — all done
+      const total = syncedCardsRef.current.reduce((sum, c) => sum + c.count, 0);
+      console.log(`[SyncWebView:amex] all phases complete — total offers synced: ${total}`);
+      onSuccess(total, syncedCardsRef.current);
+      onClose();
+      return;
+    }
+
+    // Chase multi-card
+    syncedCountRef.current += 1;
+    const totalCards = cardOptionsRef.current.length;
+    if (syncedCountRef.current < totalCards) {
+      const nextPos = (cardIndexRef.current + 1) % totalCards;
+      cardIndexRef.current = nextPos;
+      setCardIndexUi(nextPos);
+      setSwitching(true);
+      switchRetriesRef.current = 0;
+      cardsDiscovered.current  = false;
+      webViewRef.current?.injectJavaScript(buildSwitchCardJs(cardOptionsRef.current[nextPos].index, SWITCH_TIMEOUT_MS));
+    } else {
+      const total = syncedCardsRef.current.reduce((sum, c) => sum + c.count, 0);
+      onSuccess(total, syncedCardsRef.current);
+      onClose();
+    }
   };
 
   // ── Message handler ───────────────────────────────────────────
@@ -248,27 +301,43 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       if (data.type === 'AMEX_CARDS_DETECTED') {
         const hasCards = data.cards?.length > 0;
         console.log(`[SyncWebView:amex] AMEX_CARDS_DETECTED count=${data.cards?.length} phase=${syncPhaseRef.current} alreadyDiscovered=${cardsDiscovered.current}`);
-        if (!cardsDiscovered.current && hasCards && syncPhaseRef.current === 'eligible' && cardOptionsRef.current.length === 0) {
+        if (!cardsDiscovered.current && hasCards && cardOptionsRef.current.length === 0) {
+          // Only store cards once (eligible phase) — reuse for enrolled
           cardOptionsRef.current = data.cards;
           setCardCount(data.cards.length);
           const activeIdx = data.cards.findIndex(c => c.selected);
           cardIndexRef.current = activeIdx >= 0 ? activeIdx : 0;
           setCardIndexUi(cardIndexRef.current);
-          console.log(`[SyncWebView:amex] stored ${data.cards.length} cards, activeIdx=${cardIndexRef.current}`);
+          console.log(`[SyncWebView:amex] stored ${data.cards.length} cards`);
         }
         if (!cardsDiscovered.current) cardsDiscovered.current = true;
         setCurrentCard(data.selectedLabel || null);
+
+        // Enrolled phase: cards already known, start switching immediately
+        if (syncPhaseRef.current === 'enrolled' && syncStarted) {
+          console.log('[SyncWebView:amex] enrolled page ready — starting card cycle');
+          const activeCard = data.cards?.find(c => c.selected) ?? cardOptionsRef.current[0];
+          initialActiveRef.current = activeCard?.testId ?? null;
+          switchToNextAmexCard();
+        }
         return;
       }
 
-      // ── Card switched (Chase + Amex) ──────────────────
+      // ── Card switched ─────────────────────────────────────
       if (data.type === 'CARD_SWITCHED') {
         console.log(`[SyncWebView:${bank}] CARD_SWITCHED cardLabel=${data.cardLabel}`);
         setSwitching(false);
         setCurrentCard(data.cardLabel || null);
         if (bank === 'amex') {
+          // CAPTURE_JSON already fired before this — just update label for next use
           pendingCardLabelRef.current = data.cardLabel || null;
-          console.log(`[SyncWebView:amex] switch confirmed (${data.cardLabel}) — waiting for CAPTURE_JSON`);
+        } else {
+          // Chase: capture after delay
+          console.log(`[SyncWebView:chase] switch confirmed — capturing in ${POST_SWITCH_DELAY_MS}ms`);
+          setTimeout(() => {
+            captureArmed.current = true;
+            webViewRef.current?.injectJavaScript(buildCaptureJs(config.gridSelector, config.captureMaxBytes));
+          }, POST_SWITCH_DELAY_MS);
         }
         return;
       }
@@ -290,19 +359,26 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
 
       // ── Amex JSON capture ─────────────────────────────
       if (data.type === 'CAPTURE_JSON' && bank === 'amex') {
-        console.log(`[SyncWebView:amex] CAPTURE_JSON received — captureArmed=${captureArmed.current} cardLabel=${data.cardLabel}`);
+        console.log(`[SyncWebView:amex] CAPTURE_JSON — captureArmed=${captureArmed.current} cardLabel=${data.cardLabel}`);
         if (!captureArmed.current) {
           console.log('[SyncWebView:amex] CAPTURE_JSON ignored — not armed');
           return;
         }
         captureArmed.current = false;
-        const resolvedLabel = pendingCardLabelRef.current || data.cardLabel;
-        pendingCardLabelRef.current = null;
-        console.log(`[SyncWebView:amex] ✅ CAPTURE_JSON confirmed — card switch DID trigger the API call!`);
+
+        // Find the testId of the card that just fired the API
+        const cards = cardOptionsRef.current;
+        const capturedCard = cards.find(c =>
+          data.cardLabel && (c.label + (c.last4 ? ` (...${c.last4})` : '')) === data.cardLabel
+        );
+        const capturedTestId = capturedCard?.testId ?? null;
+        console.log(`[SyncWebView:amex] captured testId=${capturedTestId} label=${data.cardLabel}`);
+
         await handleCaptureResult({
-          payload:   data.json,
-          cardLabel: resolvedLabel,
-          phase:     syncPhaseRef.current,
+          payload:         data.json,
+          cardLabel:       data.cardLabel,
+          phase:           syncPhaseRef.current,
+          capturedTestId,
         });
         return;
       }
@@ -313,18 +389,15 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         return;
       }
       captureArmed.current = false;
-      console.log(`[SyncWebView:chase] CAPTURE_HTML received — html.length=${data.html?.length} cardLabel=${data.cardLabel}`);
-      const resolvedLabel = pendingCardLabelRef.current || data.cardLabel;
-      pendingCardLabelRef.current = null;
+      console.log(`[SyncWebView:chase] CAPTURE_HTML — html.length=${data.html?.length} cardLabel=${data.cardLabel}`);
       await handleCaptureResult({
         payload:   data.html,
-        cardLabel: resolvedLabel,
+        cardLabel: data.cardLabel,
         phase:     syncPhaseRef.current,
       });
 
     } catch (err) {
       captureArmed.current        = false;
-      switchPendingRef.current    = null;
       pendingCardLabelRef.current = null;
       setSyncing(false);
       setSwitching(false);

--- a/mobile/components/SyncWebView.js
+++ b/mobile/components/SyncWebView.js
@@ -21,9 +21,9 @@
 //   Phase 2 (enrolled) — auto after all eligible cards done
 //
 // Amex card switching strategy:
-//   After capturing a card, we switch via the dropdown THEN reload the page.
-//   This forces a fresh render with the new card's offers.
-//   On loadEnd, if reloadPendingCaptureRef is set we auto-arm capture.
+//   After capturing card N, we reload the page fresh, THEN switch to card N+1.
+//   switchPendingRef holds the next card to switch to after reload.
+//   On loadEnd with switchPendingRef set: switch card, then capture after delay.
 //
 // Adding a new bank:
 //   1. Add entry to sync/bankConfig.js
@@ -53,17 +53,16 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
   const webViewRef = useRef(null);
 
   // ── Sync state refs (not UI) ──────────────────────────────────
-  const cardOptionsRef          = useRef([]);
-  const cardIndexRef            = useRef(0);
-  const syncedCardsRef          = useRef([]);
-  const cardsDiscovered         = useRef(false);
-  const switchRetriesRef        = useRef(0);
-  const syncedCountRef          = useRef(0);
-  const captureArmed            = useRef(false);
-  const autoCapturing           = useRef(false);
-  const syncPhaseRef            = useRef('eligible');
-  // When true, the next loadEnd for this phase should auto-arm capture
-  const reloadPendingCaptureRef = useRef(false);
+  const cardOptionsRef    = useRef([]);
+  const cardIndexRef      = useRef(0);
+  const syncedCardsRef    = useRef([]);
+  const cardsDiscovered   = useRef(false);
+  const switchRetriesRef  = useRef(0);
+  const syncedCountRef    = useRef(0);
+  const captureArmed      = useRef(false);
+  const syncPhaseRef      = useRef('eligible');
+  // After reload, switch to this card then capture
+  const switchPendingRef  = useRef(null); // { testId, cardIndex }
 
   // ── UI state ──────────────────────────────────────────────────
   const [syncing, setSyncing]           = useState(false);
@@ -82,16 +81,15 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
   // ── Reset on close ────────────────────────────────────────────
   useEffect(() => {
     if (!visible) {
-      cardOptionsRef.current          = [];
-      cardIndexRef.current            = 0;
-      syncedCardsRef.current          = [];
-      cardsDiscovered.current         = false;
-      switchRetriesRef.current        = 0;
-      syncedCountRef.current          = 0;
-      captureArmed.current            = false;
-      autoCapturing.current           = false;
-      syncPhaseRef.current            = 'eligible';
-      reloadPendingCaptureRef.current = false;
+      cardOptionsRef.current   = [];
+      cardIndexRef.current     = 0;
+      syncedCardsRef.current   = [];
+      cardsDiscovered.current  = false;
+      switchRetriesRef.current = 0;
+      syncedCountRef.current   = 0;
+      captureArmed.current     = false;
+      syncPhaseRef.current     = 'eligible';
+      switchPendingRef.current = null;
       setCurrentCard(null);
       setCurrentUrl('');
       setSyncing(false);
@@ -107,27 +105,17 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
 
   // ── Helpers ───────────────────────────────────────────────────
   const resetForPhase = (phase) => {
-    cardIndexRef.current            = 0;
-    syncedCountRef.current          = 0;
-    cardsDiscovered.current         = false;
-    switchRetriesRef.current        = 0;
-    captureArmed.current            = false;
-    autoCapturing.current           = false;
-    reloadPendingCaptureRef.current = false;
-    syncPhaseRef.current            = phase;
+    cardIndexRef.current     = 0;
+    syncedCountRef.current   = 0;
+    cardsDiscovered.current  = false;
+    switchRetriesRef.current = 0;
+    captureArmed.current     = false;
+    switchPendingRef.current = null;
+    syncPhaseRef.current     = phase;
     setSyncPhaseUi(phase);
     setCardIndexUi(0);
     setSwitching(false);
     setSyncing(false);
-  };
-
-  // Switch to next Amex card then reload the page so the offer list refreshes.
-  // On loadEnd, reloadPendingCaptureRef causes auto-capture of the fresh page.
-  const amexSwitchAndReload = (nextCard, pageUrl) => {
-    setSwitching(true);
-    switchRetriesRef.current = 0;
-    webViewRef.current?.injectJavaScript(buildAmexSwitchCardJs(nextCard.testId, SWITCH_TIMEOUT_MS));
-    // CARD_SWITCHED handler will set reloadPendingCaptureRef and reload
   };
 
   // ── Navigation handlers ───────────────────────────────────────
@@ -136,9 +124,7 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
     if (!navState.url) return;
     console.log(`[SyncWebView:${bank}] navState url:`, navState.url);
     setCurrentUrl(navState.url);
-
     if (config.useAmexCardSwitcher) return;
-
     setPageLoaded(false);
     setOnOffersPage(false);
     if (!config.useCardsDetectedAsOffersSignal) {
@@ -169,16 +155,13 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       });
       setOnOffersPage(onOffers);
 
-      // After a switch+reload, auto-arm capture on the freshly loaded page
-      if (onOffers && reloadPendingCaptureRef.current) {
-        console.log(`[SyncWebView:amex] reload complete — auto-arming capture (phase=${syncPhaseRef.current})`);
-        reloadPendingCaptureRef.current = false;
-        cardsDiscovered.current = false; // allow re-detection on fresh page
-        // Small delay to let the offer grid fully render
-        setTimeout(() => {
-          captureArmed.current = true;
-          webViewRef.current?.injectJavaScript(buildCaptureJs(config.gridSelector, config.captureMaxBytes));
-        }, POST_SWITCH_DELAY_MS);
+      // If a switch is pending (we reloaded the page to get a fresh list),
+      // inject the switch JS now that the page is loaded fresh.
+      if (onOffers && switchPendingRef.current) {
+        const pending = switchPendingRef.current;
+        switchPendingRef.current = null;
+        console.log(`[SyncWebView:amex] page reloaded — now switching to card testId=${pending.testId}`);
+        webViewRef.current?.injectJavaScript(buildAmexSwitchCardJs(pending.testId, SWITCH_TIMEOUT_MS));
       }
       return;
     }
@@ -191,7 +174,7 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
   };
 
   const handleSyncPress = () => {
-    console.log(`[SyncWebView:${bank}] Sync pressed — gridSelector:`, config.gridSelector);
+    console.log(`[SyncWebView:${bank}] Sync pressed`);
     setSyncStarted(true);
     captureArmed.current = true;
     webViewRef.current?.injectJavaScript(buildCaptureJs(config.gridSelector, config.captureMaxBytes));
@@ -227,18 +210,24 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       if (data.type === 'AMEX_CARDS_DETECTED') {
         console.log('[SyncWebView:amex] AMEX_CARDS_DETECTED cards:', data.cards?.length, 'phase:', syncPhaseRef.current);
         const hasCards = data.cards?.length > 0;
-        if (!cardsDiscovered.current && hasCards) {
-          // On eligible phase first load: store all cards for switching
-          // On enrolled phase or reloads: just pick up the current card label
-          if (syncPhaseRef.current === 'eligible' && cardOptionsRef.current.length === 0) {
-            cardOptionsRef.current = data.cards;
-            setCardCount(data.cards.length);
-            const activeIdx = data.cards.findIndex(c => c.selected);
-            cardIndexRef.current = activeIdx >= 0 ? activeIdx : 0;
-            setCardIndexUi(cardIndexRef.current);
-          }
-          cardsDiscovered.current = true;
-          setCurrentCard(data.selectedLabel || null);
+        // Only store cards on the very first eligible detection
+        if (!cardsDiscovered.current && hasCards && syncPhaseRef.current === 'eligible' && cardOptionsRef.current.length === 0) {
+          cardOptionsRef.current = data.cards;
+          setCardCount(data.cards.length);
+          const activeIdx = data.cards.findIndex(c => c.selected);
+          cardIndexRef.current = activeIdx >= 0 ? activeIdx : 0;
+          setCardIndexUi(cardIndexRef.current);
+        }
+        if (!cardsDiscovered.current) cardsDiscovered.current = true;
+        setCurrentCard(data.selectedLabel || null);
+
+        // Enrolled phase: first load, auto-capture whichever card is shown
+        if (syncPhaseRef.current === 'enrolled' && !captureArmed.current) {
+          console.log('[SyncWebView:amex] enrolled page ready — arming capture');
+          setTimeout(() => {
+            captureArmed.current = true;
+            webViewRef.current?.injectJavaScript(buildCaptureJs(config.gridSelector, config.captureMaxBytes));
+          }, POST_SWITCH_DELAY_MS);
         }
         return;
       }
@@ -266,20 +255,18 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         setCurrentCard(data.cardLabel || null);
 
         if (bank === 'amex') {
-          // Switch confirmed — reload the page so offer list is fresh
-          const reloadUrl = syncPhaseRef.current === 'enrolled' ? config.enrolledUrl : config.offersUrl || config.url;
-          console.log(`[SyncWebView:amex] switch confirmed, reloading ${reloadUrl} (phase=${syncPhaseRef.current})`);
-          reloadPendingCaptureRef.current = true;
-          cardsDiscovered.current = false;
-          webViewRef.current?.injectJavaScript(`window.location.replace('${reloadUrl}'); true;`);
+          // Switch confirmed on fresh page — now capture
+          console.log(`[SyncWebView:amex] switch confirmed (${data.cardLabel}) — arming capture`);
+          setTimeout(() => {
+            captureArmed.current = true;
+            webViewRef.current?.injectJavaScript(buildCaptureJs(config.gridSelector, config.captureMaxBytes));
+          }, POST_SWITCH_DELAY_MS);
           return;
         }
 
         // Chase: capture after delay
-        autoCapturing.current = true;
         setTimeout(() => {
-          captureArmed.current  = true;
-          autoCapturing.current = false;
+          captureArmed.current = true;
           webViewRef.current?.injectJavaScript(buildCaptureJs(config.gridSelector, config.captureMaxBytes));
         }, POST_SWITCH_DELAY_MS);
         return;
@@ -316,15 +303,12 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         ? (cardLast4 ? `${cardName} (...${cardLast4})` : cardName)
         : null;
 
-      console.log(`[SyncWebView:${bank}] POSTing — bank=${bank} cardName=${fullCardName} phase=${syncPhaseRef.current}`);
-
       const response = await fetch(`${API_BASE_URL}/api/offers/parse`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
         body: JSON.stringify({ html: data.html, bank, cardName: fullCardName, phase: syncPhaseRef.current }),
       });
       const result = await response.json();
-      console.log(`[SyncWebView:${bank}] API response:`, JSON.stringify(result));
       if (!response.ok) throw new Error(result.error || 'Sync failed');
 
       syncedCardsRef.current = [
@@ -338,31 +322,33 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       setSyncing(false);
 
       if (syncedCountRef.current < totalCards) {
-        // More cards to sync in this phase — switch then reload
-        const nextPos = (cardIndexRef.current + 1) % totalCards;
+        // More cards in this phase — reload page first, then switch on loadEnd
+        const nextPos  = (cardIndexRef.current + 1) % totalCards;
         cardIndexRef.current = nextPos;
         setCardIndexUi(nextPos);
+        setSwitching(true);
+        switchRetriesRef.current = 0;
+        cardsDiscovered.current  = false;
+
         if (bank === 'amex') {
           const nextCard = cardOptionsRef.current[nextPos];
-          amexSwitchAndReload(nextCard);
+          const reloadUrl = currentPhase === 'enrolled' ? config.enrolledUrl : (config.offersUrl || config.url);
+          console.log(`[SyncWebView:amex] reloading ${reloadUrl} then will switch to ${nextCard.testId}`);
+          switchPendingRef.current = { testId: nextCard.testId, cardIndex: nextPos };
+          webViewRef.current?.injectJavaScript(`window.location.replace('${reloadUrl}'); true;`);
         } else {
-          setSwitching(true);
-          switchRetriesRef.current = 0;
           webViewRef.current?.injectJavaScript(buildSwitchCardJs(cardOptionsRef.current[nextPos].index, SWITCH_TIMEOUT_MS));
         }
       } else if (bank === 'amex' && currentPhase === 'eligible') {
-        // All eligible cards done — move to enrolled phase
         transitionToEnrolled();
       } else {
-        // All done
         const total = syncedCardsRef.current.reduce((sum, c) => sum + c.count, 0);
         onSuccess(total, syncedCardsRef.current);
         onClose();
       }
     } catch (err) {
-      captureArmed.current            = false;
-      autoCapturing.current           = false;
-      reloadPendingCaptureRef.current = false;
+      captureArmed.current     = false;
+      switchPendingRef.current = null;
       setSyncing(false);
       setSwitching(false);
       console.error(`[SyncWebView:${bank}] handleMessage error:`, err.message);
@@ -376,7 +362,7 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
   const phaseLabel   = syncPhaseUi === 'enrolled' ? 'activated' : 'eligible';
 
   const statusText = switching
-    ? `⏳ Switching card — reloading offers...`
+    ? `⏳ Switching card — reloading...`
     : syncing
       ? `🔄 Syncing ${phaseLabel} offers — ${cardName || 'card'} (${cardIndexUi + 1} of ${totalCards})...`
       : `⚡ Processing...`;

--- a/mobile/components/SyncWebView.js
+++ b/mobile/components/SyncWebView.js
@@ -18,14 +18,18 @@
 //
 // Amex two-phase sync:
 //   Phase 1 (eligible) — user taps "Sync Offers"
-//     → injects JSON interceptor, waits for CAPTURE_JSON
+//     → reloads the page; interceptor arms on loadEnd, catches API call
 //   Phase 2 (enrolled) — auto after all eligible cards done
-//     → same JSON interceptor pattern
+//     → same reload pattern
 //
 // Amex capture strategy:
 //   Instead of capturing DOM HTML, we inject buildAmexJsonCaptureJs()
 //   which intercepts the ReadOffersHubPresentation XHR/fetch response.
-//   This gives us clean structured JSON instead of raw HTML.
+//   The interceptor is armed on every loadEnd for Amex offers pages.
+//   On sync press we RELOAD the page — this triggers a fresh API call
+//   which the already-armed interceptor catches and posts as CAPTURE_JSON.
+//   We must NOT re-inject on sync press because the API call already fired
+//   on the initial page load; re-injecting just waits for a call that never comes.
 //   CAPTURE_JSON message is handled here; CAPTURE_HTML is Chase-only.
 //
 // Amex card switching strategy:
@@ -175,7 +179,10 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       setOnOffersPage(onOffers);
 
       if (onOffers) {
-        console.log(`[SyncWebView:amex] arming JSON interceptor on loadEnd (phase=${syncPhaseRef.current})`);
+        // Always arm interceptor on offers page load.
+        // On sync press we reload → this loadEnd fires again →
+        // interceptor re-arms → catches the fresh API call → CAPTURE_JSON.
+        console.log(`[SyncWebView:amex] arming JSON interceptor on loadEnd (phase=${syncPhaseRef.current} captureArmed=${captureArmed.current})`);
         webViewRef.current?.injectJavaScript(buildAmexJsonCaptureJs());
       }
 
@@ -197,13 +204,19 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
 
   // ── Sync press — bank-specific capture trigger ─────────────────
   const handleSyncPress = () => {
-    console.log(`[SyncWebView:${bank}] Sync pressed — phase=${syncPhaseRef.current} captureArmed=${captureArmed.current}`);
+    console.log(`[SyncWebView:${bank}] Sync pressed — phase=${syncPhaseRef.current}`);
     setSyncStarted(true);
     captureArmed.current = true;
 
     if (bank === 'amex') {
-      console.log('[SyncWebView:amex] re-injecting JSON interceptor on sync press');
-      webViewRef.current?.injectJavaScript(buildAmexJsonCaptureJs());
+      // Reload the page so Amex fires a fresh ReadOffersHubPresentation API call.
+      // The interceptor will be re-armed in handleLoadEnd (on the fresh load)
+      // and will catch that call automatically.
+      const reloadUrl = syncPhaseRef.current === 'enrolled'
+        ? config.enrolledUrl
+        : (config.offersUrl || config.url);
+      console.log(`[SyncWebView:amex] reloading ${reloadUrl} to trigger fresh API call`);
+      webViewRef.current?.injectJavaScript(`window.location.replace('${reloadUrl}'); true;`);
       return;
     }
 

--- a/mobile/components/SyncWebView.js
+++ b/mobile/components/SyncWebView.js
@@ -346,16 +346,15 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         }
         captureArmed.current = false;
 
-        // ── DEBUG: dump raw offersList to api/debug-dumps/ ──
-        const offersList = data.json?.recommendedOffers?.offersList;
-        const cardLabel  = data.cardLabel || 'unknown';
-        const safeLabel  = cardLabel.replace(/[^a-z0-9]/gi, '_');
+        // ── DEBUG: dump full raw response (no filtering) to api/debug-dumps/ ──
+        const cardLabel = data.cardLabel || 'unknown';
+        const safeLabel = cardLabel.replace(/[^a-z0-9]/gi, '_');
         fetch(`${API_BASE_URL}/api/debug/dump`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ label: `offersList_${safeLabel}`, data: offersList ?? null }),
+          body: JSON.stringify({ label: `rawResponse_${safeLabel}`, data: data.json ?? null }),
         }).then(r => r.json()).then(r => console.log('[SyncWebView:amex] debug dump:', r.file));
-        // ───────────────────────────────────────────────────────
+        // ─────────────────────────────────────────────────────────────────────
 
         const cards = cardOptionsRef.current;
         const capturedCard = cards.find(c =>

--- a/mobile/components/SyncWebView.js
+++ b/mobile/components/SyncWebView.js
@@ -77,9 +77,7 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
   const syncedCountRef      = useRef(0);
   const captureArmed        = useRef(false);
   const syncPhaseRef        = useRef('eligible');
-  // After reload, switch to this card then capture
-  const switchPendingRef    = useRef(null); // { testId, cardIndex }
-  // Stores cardLabel from CARD_SWITCHED to avoid stale DOM read
+  const switchPendingRef    = useRef(null);
   const pendingCardLabelRef = useRef(null);
 
   // ── UI state ──────────────────────────────────────────────────
@@ -124,6 +122,7 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
 
   // ── Helpers ───────────────────────────────────────────────────
   const resetForPhase = (phase) => {
+    console.log(`[SyncWebView:amex] resetForPhase phase=${phase}`);
     cardIndexRef.current        = 0;
     syncedCountRef.current      = 0;
     cardsDiscovered.current     = false;
@@ -175,19 +174,15 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       });
       setOnOffersPage(onOffers);
 
-      // Always (re-)arm the JSON interceptor on every Amex page load so it's
-      // ready for the initial load and for any subsequent card switch API call.
       if (onOffers) {
+        console.log(`[SyncWebView:amex] arming JSON interceptor on loadEnd (phase=${syncPhaseRef.current})`);
         webViewRef.current?.injectJavaScript(buildAmexJsonCaptureJs());
       }
 
-      // If a switch is pending (we reloaded to get a fresh page),
-      // inject the switch JS now — the JSON interceptor will catch the
-      // resulting API call automatically.
       if (onOffers && switchPendingRef.current) {
         const pending = switchPendingRef.current;
         switchPendingRef.current = null;
-        console.log(`[SyncWebView:amex] page reloaded — now switching to card testId=${pending.testId}`);
+        console.log(`[SyncWebView:amex] page reloaded — switching to testId=${pending.testId} (cardIndex=${pending.cardIndex})`);
         webViewRef.current?.injectJavaScript(buildAmexSwitchCardJs(pending.testId, SWITCH_TIMEOUT_MS));
       }
       return;
@@ -202,16 +197,12 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
 
   // ── Sync press — bank-specific capture trigger ─────────────────
   const handleSyncPress = () => {
-    console.log(`[SyncWebView:${bank}] Sync pressed`);
+    console.log(`[SyncWebView:${bank}] Sync pressed — phase=${syncPhaseRef.current} captureArmed=${captureArmed.current}`);
     setSyncStarted(true);
     captureArmed.current = true;
 
     if (bank === 'amex') {
-      // JSON interceptor already armed on loadEnd.
-      // Just re-arm the flag and wait for the next ReadOffersHubPresentation call
-      // which will fire naturally when the user-visible card loads.
-      // If no call arrives (page was already fully loaded), we trigger a
-      // lightweight re-arm by re-injecting the interceptor.
+      console.log('[SyncWebView:amex] re-injecting JSON interceptor on sync press');
       webViewRef.current?.injectJavaScript(buildAmexJsonCaptureJs());
       return;
     }
@@ -238,19 +229,21 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       ? (cardLast4 ? `${cardName} (...${cardLast4})` : cardName)
       : null;
 
-    // Amex sends JSON; Chase sends HTML
-    const body = bank === 'amex'
-      ? JSON.stringify({ json: payload, bank, cardName: fullCardName, phase })
-      : JSON.stringify({ html: payload, bank, cardName: fullCardName, phase });
+    const isAmex = bank === 'amex';
+    const bodyObj = isAmex
+      ? { json: payload, bank, cardName: fullCardName, phase }
+      : { html: payload, bank, cardName: fullCardName, phase };
 
-    console.log(`[SyncWebView:${bank}] POSTing to ${API_BASE_URL}/api/offers/parse — cardName=${fullCardName} phase=${phase}`);
+    console.log(`[SyncWebView:${bank}] handleCaptureResult — phase=${phase} cardName=${fullCardName} payloadType=${isAmex ? 'json' : 'html'} payloadSize=${isAmex ? JSON.stringify(payload).length : payload?.length}`);
+    console.log(`[SyncWebView:${bank}] POSTing to ${API_BASE_URL}/api/offers/parse`);
 
     const response = await fetch(`${API_BASE_URL}/api/offers/parse`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
-      body,
+      body: JSON.stringify(bodyObj),
     });
     const result = await response.json();
+    console.log(`[SyncWebView:${bank}] API /parse response:`, JSON.stringify(result));
     if (!response.ok) throw new Error(result.error || 'Sync failed');
 
     syncedCardsRef.current = [
@@ -259,7 +252,8 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
     ];
     syncedCountRef.current += 1;
 
-    const totalCards   = cardOptionsRef.current.length;
+    const totalCards = cardOptionsRef.current.length;
+    console.log(`[SyncWebView:${bank}] syncedCount=${syncedCountRef.current} totalCards=${totalCards} phase=${phase}`);
     setSyncing(false);
 
     if (syncedCountRef.current < totalCards) {
@@ -273,16 +267,18 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       if (bank === 'amex') {
         const nextCard  = cardOptionsRef.current[nextPos];
         const reloadUrl = phase === 'enrolled' ? config.enrolledUrl : (config.offersUrl || config.url);
-        console.log(`[SyncWebView:amex] reloading ${reloadUrl} then switching to ${nextCard.testId}`);
+        console.log(`[SyncWebView:amex] reloading ${reloadUrl} — will switch to testId=${nextCard.testId} after load`);
         switchPendingRef.current = { testId: nextCard.testId, cardIndex: nextPos };
         webViewRef.current?.injectJavaScript(`window.location.replace('${reloadUrl}'); true;`);
       } else {
         webViewRef.current?.injectJavaScript(buildSwitchCardJs(cardOptionsRef.current[nextPos].index, SWITCH_TIMEOUT_MS));
       }
     } else if (bank === 'amex' && phase === 'eligible') {
+      console.log('[SyncWebView:amex] all eligible cards done — transitioning to enrolled phase');
       transitionToEnrolled();
     } else {
       const total = syncedCardsRef.current.reduce((sum, c) => sum + c.count, 0);
+      console.log(`[SyncWebView:${bank}] all phases done — total offers synced: ${total}`);
       onSuccess(total, syncedCardsRef.current);
       onClose();
     }
@@ -292,11 +288,12 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
   const handleMessage = async (event) => {
     try {
       const data = JSON.parse(event.nativeEvent.data);
-      console.log(`[SyncWebView:${bank}] message type:`, data.type, data.error || '');
+      console.log(`[SyncWebView:${bank}] ✉️ message type=${data.type}`, data.error ? `error=${data.error}` : '');
 
       // ── Chase card detection ──────────────────────────
       if (data.type === 'CARDS_DETECTED') {
         const hasCards = data.cards?.length > 0;
+        console.log(`[SyncWebView:chase] CARDS_DETECTED count=${data.cards?.length} selected=${data.selectedLabel}`);
         if (!cardsDiscovered.current && hasCards) {
           cardOptionsRef.current  = data.cards;
           cardsDiscovered.current = true;
@@ -312,23 +309,21 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
 
       // ── Amex card detection ───────────────────────────
       if (data.type === 'AMEX_CARDS_DETECTED') {
-        console.log('[SyncWebView:amex] AMEX_CARDS_DETECTED cards:', data.cards?.length, 'phase:', syncPhaseRef.current);
         const hasCards = data.cards?.length > 0;
+        console.log(`[SyncWebView:amex] AMEX_CARDS_DETECTED count=${data.cards?.length} phase=${syncPhaseRef.current} alreadyDiscovered=${cardsDiscovered.current}`);
         if (!cardsDiscovered.current && hasCards && syncPhaseRef.current === 'eligible' && cardOptionsRef.current.length === 0) {
           cardOptionsRef.current = data.cards;
           setCardCount(data.cards.length);
           const activeIdx = data.cards.findIndex(c => c.selected);
           cardIndexRef.current = activeIdx >= 0 ? activeIdx : 0;
           setCardIndexUi(cardIndexRef.current);
+          console.log(`[SyncWebView:amex] stored ${data.cards.length} cards, activeIdx=${cardIndexRef.current}`);
         }
         if (!cardsDiscovered.current) cardsDiscovered.current = true;
         setCurrentCard(data.selectedLabel || null);
 
-        // Enrolled phase: first load, auto-capture whichever card is shown.
-        // The JSON interceptor is already armed from loadEnd — no explicit
-        // capture trigger needed; the interceptor fires on the API call.
         if (syncPhaseRef.current === 'enrolled' && !captureArmed.current) {
-          console.log('[SyncWebView:amex] enrolled page ready — arming capture');
+          console.log('[SyncWebView:amex] enrolled page ready — arming captureArmed flag');
           captureArmed.current = true;
         }
         return;
@@ -336,14 +331,18 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
 
       // ── Card switched (Chase + Amex) ──────────────────
       if (data.type === 'CARD_SWITCHED') {
+        console.log(`[SyncWebView:${bank}] CARD_SWITCHED cardLabel=${data.cardLabel} expectedTestId=${data.expectedTestId || data.expectedIndex}`);
         const switchConfirmed = bank === 'amex' ? !!data.cardLabel : (() => {
           const expectedLabel = cardOptionsRef.current.find(c => c.index === data.expectedIndex)?.label || '';
-          return expectedLabel ? data.cardLabel?.trim() === expectedLabel.trim() : !!data.cardLabel;
+          const confirmed = expectedLabel ? data.cardLabel?.trim() === expectedLabel.trim() : !!data.cardLabel;
+          console.log(`[SyncWebView:chase] switch confirm: expected="${expectedLabel}" got="${data.cardLabel}" confirmed=${confirmed}`);
+          return confirmed;
         })();
 
         if (!switchConfirmed && switchRetriesRef.current < MAX_SWITCH_RETRIES) {
           switchRetriesRef.current += 1;
           const retryDelay = SWITCH_TIMEOUT_MS + switchRetriesRef.current * 1500;
+          console.log(`[SyncWebView:${bank}] switch not confirmed, retry ${switchRetriesRef.current}/${MAX_SWITCH_RETRIES} in ${retryDelay}ms`);
           if (bank === 'amex') {
             const card = cardOptionsRef.current[cardIndexRef.current];
             webViewRef.current?.injectJavaScript(buildAmexSwitchCardJs(card.testId, retryDelay));
@@ -358,16 +357,13 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         setCurrentCard(data.cardLabel || null);
 
         if (bank === 'amex') {
-          // Store label now — DOM may be stale by capture time
           pendingCardLabelRef.current = data.cardLabel || null;
-          // Amex: JSON interceptor is already armed and will fire automatically
-          // when the card switch triggers a new ReadOffersHubPresentation call.
-          // No explicit capture injection needed here.
-          console.log(`[SyncWebView:amex] switch confirmed (${data.cardLabel}) — JSON interceptor will capture`);
+          console.log(`[SyncWebView:amex] switch confirmed (${data.cardLabel}) — JSON interceptor will fire on next API call`);
           return;
         }
 
         // Chase: capture after delay
+        console.log(`[SyncWebView:chase] switch confirmed — capturing HTML in ${POST_SWITCH_DELAY_MS}ms`);
         setTimeout(() => {
           captureArmed.current = true;
           webViewRef.current?.injectJavaScript(buildCaptureJs(config.gridSelector, config.captureMaxBytes));
@@ -376,6 +372,7 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       }
 
       if (data.type === 'CARD_SWITCH_ERROR') {
+        console.log(`[SyncWebView:${bank}] CARD_SWITCH_ERROR:`, data.message);
         setSwitching(false);
         captureArmed.current = false;
         Alert.alert('Card Switch Failed', data.message);
@@ -383,6 +380,7 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       }
 
       if (data.type === 'ERROR') {
+        console.log(`[SyncWebView:${bank}] ERROR from WebView:`, data.message);
         captureArmed.current = false;
         Alert.alert('Capture Error', data.message);
         return;
@@ -390,15 +388,16 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
 
       // ── Amex JSON capture ─────────────────────────────
       if (data.type === 'CAPTURE_JSON' && bank === 'amex') {
+        console.log(`[SyncWebView:amex] CAPTURE_JSON received — captureArmed=${captureArmed.current} cardLabel=${data.cardLabel} jsonKeys=${Object.keys(data.json || {}).join(',')}`);
         if (!captureArmed.current) {
-          console.log('[SyncWebView:amex] CAPTURE_JSON received but not armed — ignoring');
+          console.log('[SyncWebView:amex] CAPTURE_JSON ignored — not armed');
           return;
         }
         captureArmed.current = false;
-        console.log(`[SyncWebView:amex] CAPTURE_JSON received — cardLabel=${data.cardLabel} phase=${syncPhaseRef.current}`);
 
         const resolvedLabel = pendingCardLabelRef.current || data.cardLabel;
         pendingCardLabelRef.current = null;
+        console.log(`[SyncWebView:amex] resolvedLabel=${resolvedLabel} phase=${syncPhaseRef.current}`);
 
         await handleCaptureResult({
           payload:   data.json,
@@ -414,8 +413,7 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         return;
       }
       captureArmed.current = false;
-
-      console.log(`[SyncWebView:${bank}] CAPTURE_HTML received — html.length=${data.html?.length} cardLabel=${data.cardLabel} phase=${syncPhaseRef.current}`);
+      console.log(`[SyncWebView:chase] CAPTURE_HTML received — html.length=${data.html?.length} cardLabel=${data.cardLabel}`);
 
       const resolvedLabel = pendingCardLabelRef.current || data.cardLabel;
       pendingCardLabelRef.current = null;
@@ -432,7 +430,7 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       pendingCardLabelRef.current = null;
       setSyncing(false);
       setSwitching(false);
-      console.error(`[SyncWebView:${bank}] handleMessage error:`, err.message);
+      console.error(`[SyncWebView:${bank}] handleMessage UNHANDLED ERROR:`, err.message);
       Alert.alert('Sync Failed', err.message);
     }
   };

--- a/mobile/components/SyncWebView.js
+++ b/mobile/components/SyncWebView.js
@@ -18,12 +18,23 @@
 //
 // Amex two-phase sync:
 //   Phase 1 (eligible) — user taps "Sync Offers"
+//     → injects JSON interceptor, waits for CAPTURE_JSON
 //   Phase 2 (enrolled) — auto after all eligible cards done
+//     → same JSON interceptor pattern
+//
+// Amex capture strategy:
+//   Instead of capturing DOM HTML, we inject buildAmexJsonCaptureJs()
+//   which intercepts the ReadOffersHubPresentation XHR/fetch response.
+//   This gives us clean structured JSON instead of raw HTML.
+//   CAPTURE_JSON message is handled here; CAPTURE_HTML is Chase-only.
 //
 // Amex card switching strategy:
 //   After capturing card N, we reload the page fresh, THEN switch to card N+1.
 //   switchPendingRef holds the next card to switch to after reload.
-//   On loadEnd with switchPendingRef set: switch card, then capture after delay.
+//   On loadEnd with switchPendingRef set: switch card, JSON interceptor
+//   will fire automatically when the card switch triggers a new API call.
+//
+// Chase is completely unchanged — still uses buildCaptureJs + CAPTURE_HTML.
 //
 // Adding a new bank:
 //   1. Add entry to sync/bankConfig.js
@@ -41,7 +52,12 @@ import { colors, radii } from '../shared/theme.js';
 
 import { BANK_CONFIG }                                    from './sync/bankConfig.js';
 import { DETECT_CARDS_JS, buildSwitchCardJs }             from './sync/chaseSync.js';
-import { AMEX_OPEN_AND_DETECT_JS, buildAmexSwitchCardJs, amexHandleLoadEnd } from './sync/amexSync.js';
+import {
+  AMEX_OPEN_AND_DETECT_JS,
+  buildAmexSwitchCardJs,
+  buildAmexJsonCaptureJs,
+  amexHandleLoadEnd,
+} from './sync/amexSync.js';
 import { buildCaptureJs, parseCardLabel }                 from './sync/captureJs.js';
 
 const API_BASE_URL         = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3001';
@@ -63,7 +79,7 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
   const syncPhaseRef        = useRef('eligible');
   // After reload, switch to this card then capture
   const switchPendingRef    = useRef(null); // { testId, cardIndex }
-  // Stores cardLabel from CARD_SWITCHED to avoid stale DOM read in CAPTURE_HTML
+  // Stores cardLabel from CARD_SWITCHED to avoid stale DOM read
   const pendingCardLabelRef = useRef(null);
 
   // ── UI state ──────────────────────────────────────────────────
@@ -159,8 +175,15 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       });
       setOnOffersPage(onOffers);
 
-      // If a switch is pending (we reloaded the page to get a fresh list),
-      // inject the switch JS now that the page is loaded fresh.
+      // Always (re-)arm the JSON interceptor on every Amex page load so it's
+      // ready for the initial load and for any subsequent card switch API call.
+      if (onOffers) {
+        webViewRef.current?.injectJavaScript(buildAmexJsonCaptureJs());
+      }
+
+      // If a switch is pending (we reloaded to get a fresh page),
+      // inject the switch JS now — the JSON interceptor will catch the
+      // resulting API call automatically.
       if (onOffers && switchPendingRef.current) {
         const pending = switchPendingRef.current;
         switchPendingRef.current = null;
@@ -177,10 +200,23 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
     webViewRef.current?.injectJavaScript(`window.location.replace('${target}'); true;`);
   };
 
+  // ── Sync press — bank-specific capture trigger ─────────────────
   const handleSyncPress = () => {
     console.log(`[SyncWebView:${bank}] Sync pressed`);
     setSyncStarted(true);
     captureArmed.current = true;
+
+    if (bank === 'amex') {
+      // JSON interceptor already armed on loadEnd.
+      // Just re-arm the flag and wait for the next ReadOffersHubPresentation call
+      // which will fire naturally when the user-visible card loads.
+      // If no call arrives (page was already fully loaded), we trigger a
+      // lightweight re-arm by re-injecting the interceptor.
+      webViewRef.current?.injectJavaScript(buildAmexJsonCaptureJs());
+      return;
+    }
+
+    // Chase (and future HTML banks)
     webViewRef.current?.injectJavaScript(buildCaptureJs(config.gridSelector, config.captureMaxBytes));
   };
 
@@ -190,12 +226,75 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
     webViewRef.current?.injectJavaScript(`window.location.replace('${config.enrolledUrl}'); true;`);
   };
 
+  // ── Shared post-capture logic ─────────────────────────────────
+  const handleCaptureResult = async ({ payload, cardLabel, phase }) => {
+    setSyncing(true);
+    const user = getAuthInstance().currentUser;
+    if (!user) throw new Error('You must be signed in to sync offers.');
+    const token = await user.getIdToken();
+
+    const { cardName, cardLast4 } = parseCardLabel(cardLabel);
+    const fullCardName = cardName
+      ? (cardLast4 ? `${cardName} (...${cardLast4})` : cardName)
+      : null;
+
+    // Amex sends JSON; Chase sends HTML
+    const body = bank === 'amex'
+      ? JSON.stringify({ json: payload, bank, cardName: fullCardName, phase })
+      : JSON.stringify({ html: payload, bank, cardName: fullCardName, phase });
+
+    console.log(`[SyncWebView:${bank}] POSTing to ${API_BASE_URL}/api/offers/parse — cardName=${fullCardName} phase=${phase}`);
+
+    const response = await fetch(`${API_BASE_URL}/api/offers/parse`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body,
+    });
+    const result = await response.json();
+    if (!response.ok) throw new Error(result.error || 'Sync failed');
+
+    syncedCardsRef.current = [
+      ...syncedCardsRef.current,
+      { cardName: fullCardName || 'Unknown Card', count: result.synced ?? 0, phase },
+    ];
+    syncedCountRef.current += 1;
+
+    const totalCards   = cardOptionsRef.current.length;
+    setSyncing(false);
+
+    if (syncedCountRef.current < totalCards) {
+      const nextPos = (cardIndexRef.current + 1) % totalCards;
+      cardIndexRef.current = nextPos;
+      setCardIndexUi(nextPos);
+      setSwitching(true);
+      switchRetriesRef.current = 0;
+      cardsDiscovered.current  = false;
+
+      if (bank === 'amex') {
+        const nextCard  = cardOptionsRef.current[nextPos];
+        const reloadUrl = phase === 'enrolled' ? config.enrolledUrl : (config.offersUrl || config.url);
+        console.log(`[SyncWebView:amex] reloading ${reloadUrl} then switching to ${nextCard.testId}`);
+        switchPendingRef.current = { testId: nextCard.testId, cardIndex: nextPos };
+        webViewRef.current?.injectJavaScript(`window.location.replace('${reloadUrl}'); true;`);
+      } else {
+        webViewRef.current?.injectJavaScript(buildSwitchCardJs(cardOptionsRef.current[nextPos].index, SWITCH_TIMEOUT_MS));
+      }
+    } else if (bank === 'amex' && phase === 'eligible') {
+      transitionToEnrolled();
+    } else {
+      const total = syncedCardsRef.current.reduce((sum, c) => sum + c.count, 0);
+      onSuccess(total, syncedCardsRef.current);
+      onClose();
+    }
+  };
+
   // ── Message handler ───────────────────────────────────────────
   const handleMessage = async (event) => {
     try {
       const data = JSON.parse(event.nativeEvent.data);
       console.log(`[SyncWebView:${bank}] message type:`, data.type, data.error || '');
 
+      // ── Chase card detection ──────────────────────────
       if (data.type === 'CARDS_DETECTED') {
         const hasCards = data.cards?.length > 0;
         if (!cardsDiscovered.current && hasCards) {
@@ -211,10 +310,10 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         return;
       }
 
+      // ── Amex card detection ───────────────────────────
       if (data.type === 'AMEX_CARDS_DETECTED') {
         console.log('[SyncWebView:amex] AMEX_CARDS_DETECTED cards:', data.cards?.length, 'phase:', syncPhaseRef.current);
         const hasCards = data.cards?.length > 0;
-        // Only store cards on the very first eligible detection
         if (!cardsDiscovered.current && hasCards && syncPhaseRef.current === 'eligible' && cardOptionsRef.current.length === 0) {
           cardOptionsRef.current = data.cards;
           setCardCount(data.cards.length);
@@ -225,17 +324,17 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         if (!cardsDiscovered.current) cardsDiscovered.current = true;
         setCurrentCard(data.selectedLabel || null);
 
-        // Enrolled phase: first load, auto-capture whichever card is shown
+        // Enrolled phase: first load, auto-capture whichever card is shown.
+        // The JSON interceptor is already armed from loadEnd — no explicit
+        // capture trigger needed; the interceptor fires on the API call.
         if (syncPhaseRef.current === 'enrolled' && !captureArmed.current) {
           console.log('[SyncWebView:amex] enrolled page ready — arming capture');
-          setTimeout(() => {
-            captureArmed.current = true;
-            webViewRef.current?.injectJavaScript(buildCaptureJs(config.gridSelector, config.captureMaxBytes));
-          }, POST_SWITCH_DELAY_MS);
+          captureArmed.current = true;
         }
         return;
       }
 
+      // ── Card switched (Chase + Amex) ──────────────────
       if (data.type === 'CARD_SWITCHED') {
         const switchConfirmed = bank === 'amex' ? !!data.cardLabel : (() => {
           const expectedLabel = cardOptionsRef.current.find(c => c.index === data.expectedIndex)?.label || '';
@@ -259,14 +358,12 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         setCurrentCard(data.cardLabel || null);
 
         if (bank === 'amex') {
-          // Store label now — DOM may be stale by the time CAPTURE_HTML fires
+          // Store label now — DOM may be stale by capture time
           pendingCardLabelRef.current = data.cardLabel || null;
-          // Switch confirmed on fresh page — now capture
-          console.log(`[SyncWebView:amex] switch confirmed (${data.cardLabel}) — arming capture`);
-          setTimeout(() => {
-            captureArmed.current = true;
-            webViewRef.current?.injectJavaScript(buildCaptureJs(config.gridSelector, config.captureMaxBytes));
-          }, POST_SWITCH_DELAY_MS);
+          // Amex: JSON interceptor is already armed and will fire automatically
+          // when the card switch triggers a new ReadOffersHubPresentation call.
+          // No explicit capture injection needed here.
+          console.log(`[SyncWebView:amex] switch confirmed (${data.cardLabel}) — JSON interceptor will capture`);
           return;
         }
 
@@ -291,6 +388,27 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         return;
       }
 
+      // ── Amex JSON capture ─────────────────────────────
+      if (data.type === 'CAPTURE_JSON' && bank === 'amex') {
+        if (!captureArmed.current) {
+          console.log('[SyncWebView:amex] CAPTURE_JSON received but not armed — ignoring');
+          return;
+        }
+        captureArmed.current = false;
+        console.log(`[SyncWebView:amex] CAPTURE_JSON received — cardLabel=${data.cardLabel} phase=${syncPhaseRef.current}`);
+
+        const resolvedLabel = pendingCardLabelRef.current || data.cardLabel;
+        pendingCardLabelRef.current = null;
+
+        await handleCaptureResult({
+          payload:   data.json,
+          cardLabel: resolvedLabel,
+          phase:     syncPhaseRef.current,
+        });
+        return;
+      }
+
+      // ── Chase HTML capture ────────────────────────────
       if (data.type !== 'CAPTURE_HTML' || !captureArmed.current) {
         console.log(`[SyncWebView:${bank}] ignoring message — type=${data.type} captureArmed=${captureArmed.current}`);
         return;
@@ -299,62 +417,15 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
 
       console.log(`[SyncWebView:${bank}] CAPTURE_HTML received — html.length=${data.html?.length} cardLabel=${data.cardLabel} phase=${syncPhaseRef.current}`);
 
-      setSyncing(true);
-      const user = getAuthInstance().currentUser;
-      if (!user) throw new Error('You must be signed in to sync offers.');
-      const token = await user.getIdToken();
-
-      // Use pendingCardLabelRef if set (avoids stale DOM label after Amex card switch)
       const resolvedLabel = pendingCardLabelRef.current || data.cardLabel;
       pendingCardLabelRef.current = null;
-      const { cardName, cardLast4 } = parseCardLabel(resolvedLabel);
-      const fullCardName = cardName
-        ? (cardLast4 ? `${cardName} (...${cardLast4})` : cardName)
-        : null;
 
-      const response = await fetch(`${API_BASE_URL}/api/offers/parse`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
-        body: JSON.stringify({ html: data.html, bank, cardName: fullCardName, phase: syncPhaseRef.current }),
+      await handleCaptureResult({
+        payload:   data.html,
+        cardLabel: resolvedLabel,
+        phase:     syncPhaseRef.current,
       });
-      const result = await response.json();
-      if (!response.ok) throw new Error(result.error || 'Sync failed');
 
-      syncedCardsRef.current = [
-        ...syncedCardsRef.current,
-        { cardName: fullCardName || 'Unknown Card', count: result.synced ?? 0, phase: syncPhaseRef.current },
-      ];
-      syncedCountRef.current += 1;
-
-      const totalCards   = cardOptionsRef.current.length;
-      const currentPhase = syncPhaseRef.current;
-      setSyncing(false);
-
-      if (syncedCountRef.current < totalCards) {
-        // More cards in this phase — reload page first, then switch on loadEnd
-        const nextPos  = (cardIndexRef.current + 1) % totalCards;
-        cardIndexRef.current = nextPos;
-        setCardIndexUi(nextPos);
-        setSwitching(true);
-        switchRetriesRef.current = 0;
-        cardsDiscovered.current  = false;
-
-        if (bank === 'amex') {
-          const nextCard = cardOptionsRef.current[nextPos];
-          const reloadUrl = currentPhase === 'enrolled' ? config.enrolledUrl : (config.offersUrl || config.url);
-          console.log(`[SyncWebView:amex] reloading ${reloadUrl} then will switch to ${nextCard.testId}`);
-          switchPendingRef.current = { testId: nextCard.testId, cardIndex: nextPos };
-          webViewRef.current?.injectJavaScript(`window.location.replace('${reloadUrl}'); true;`);
-        } else {
-          webViewRef.current?.injectJavaScript(buildSwitchCardJs(cardOptionsRef.current[nextPos].index, SWITCH_TIMEOUT_MS));
-        }
-      } else if (bank === 'amex' && currentPhase === 'eligible') {
-        transitionToEnrolled();
-      } else {
-        const total = syncedCardsRef.current.reduce((sum, c) => sum + c.count, 0);
-        onSuccess(total, syncedCardsRef.current);
-        onClose();
-      }
     } catch (err) {
       captureArmed.current        = false;
       switchPendingRef.current    = null;

--- a/mobile/components/SyncWebView.js
+++ b/mobile/components/SyncWebView.js
@@ -19,7 +19,8 @@
 //   Phase 1 (eligible) — user taps "Sync Offers"
 //   Phase 2 (enrolled) — auto after all eligible cards done
 //   Both phases use the same per-card switching + capture pipeline.
-//   incognito={true} ensures clean session every time.
+//   Cookies/session persist across syncs (no incognito) so device trust is maintained.
+//   Entry URL always starts at login page — Amex auto-redirects if session is active.
 //
 // Adding a new bank:
 //   1. Add entry to sync/bankConfig.js
@@ -103,7 +104,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
   // ── Helpers ───────────────────────────────────────────────────
 
   // Reset per-card state when transitioning to a new sync phase.
-  // Called before navigating to enrolled page.
   const resetForPhase = (phase) => {
     cardIndexRef.current     = 0;
     syncedCountRef.current   = 0;
@@ -153,17 +153,11 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       const { onOffersPage: onOffers, detectedPhase } = amexHandleLoadEnd({
         url,
         config,
-        syncPhase:       syncPhaseRef.current,
-        cardsDiscovered: cardsDiscovered.current,
+        syncPhase:        syncPhaseRef.current,
+        cardsDiscovered:  cardsDiscovered.current,
         injectJavaScript: (js) => webViewRef.current?.injectJavaScript(js),
       });
       setOnOffersPage(onOffers);
-
-      // If we auto-navigated to enrolled and it loaded, arm auto-capture
-      // for first card (cards already known, index already reset to 0)
-      if (detectedPhase === 'enrolled' && syncPhaseRef.current === 'enrolled' && onOffers) {
-        console.log('[SyncWebView:amex] enrolled page loaded — will auto-capture after card detection');
-      }
       return;
     }
 
@@ -178,7 +172,7 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
 
   // ── User taps "Sync Offers" (eligible phase only) ─────────────
   const handleSyncPress = () => {
-    console.log(`[SyncWebView:${bank}] Sync pressed — gridSelector:`, config.gridSelector, 'captureMaxBytes:', config.captureMaxBytes);
+    console.log(`[SyncWebView:${bank}] Sync pressed — gridSelector:`, config.gridSelector);
     setSyncStarted(true);
     captureArmed.current = true;
     webViewRef.current?.injectJavaScript(buildCaptureJs(config.gridSelector, config.captureMaxBytes));
@@ -188,11 +182,10 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
   const transitionToEnrolled = () => {
     console.log('[SyncWebView:amex] transitioning to enrolled phase');
     resetForPhase('enrolled');
-    // Navigate to enrolled URL — handleLoadEnd will detect it and inject card detection
     webViewRef.current?.injectJavaScript(`window.location.replace('${config.enrolledUrl}'); true;`);
   };
 
-  // ── After card detection in enrolled phase — auto-capture ─────
+  // ── Auto-capture for enrolled phase ─────────────────────────
   const autoCapureEnrolledCard = () => {
     console.log('[SyncWebView:amex] auto-capturing enrolled card at index', cardIndexRef.current);
     captureArmed.current = true;
@@ -227,8 +220,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         const hasCards = data.cards?.length > 0;
 
         if (!cardsDiscovered.current && hasCards) {
-          // For eligible phase: store cards (source of truth for card list)
-          // For enrolled phase: cards are already in cardOptionsRef, just mark discovered
           if (syncPhaseRef.current === 'eligible') {
             cardOptionsRef.current = data.cards;
             setCardCount(data.cards.length);
@@ -236,16 +227,15 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
             cardIndexRef.current = activeIdx >= 0 ? activeIdx : 0;
             setCardIndexUi(cardIndexRef.current);
           } else {
-            // enrolled: find the matching card in our stored list to keep testId consistency
-            // index already reset to 0 in resetForPhase
+            // enrolled: reuse stored card list, index already reset to 0
             setCardIndexUi(0);
           }
           cardsDiscovered.current = true;
           setCurrentCard(data.selectedLabel || null);
 
-          // enrolled phase: auto-capture the first card immediately
+          // enrolled phase: auto-switch to card 0 then capture
           if (syncPhaseRef.current === 'enrolled') {
-            console.log('[SyncWebView:amex] enrolled cards detected — switching to card 0 first');
+            console.log('[SyncWebView:amex] enrolled cards detected — switching to card 0');
             const firstCard = cardOptionsRef.current[0];
             if (firstCard) {
               setSwitching(true);
@@ -286,14 +276,12 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         setSwitching(false);
         setCurrentCard(data.cardLabel || null);
 
-        // For enrolled phase, capture immediately after switch (no extra delay needed
-        // since switch already waits SWITCH_TIMEOUT_MS)
         if (syncPhaseRef.current === 'enrolled') {
           autoCapureEnrolledCard();
           return;
         }
 
-        // Eligible phase: original delay before capture
+        // Eligible phase: delay before capture
         autoCapturing.current = true;
         setTimeout(() => {
           captureArmed.current  = true;
@@ -356,7 +344,7 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       setSyncing(false);
 
       if (syncedCountRef.current < totalCards) {
-        // More cards to sync in this phase
+        // More cards in this phase
         const nextPos = (cardIndexRef.current + 1) % totalCards;
         cardIndexRef.current = nextPos;
         setCardIndexUi(nextPos);
@@ -369,10 +357,10 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
           webViewRef.current?.injectJavaScript(buildSwitchCardJs(cardOptionsRef.current[nextPos].index, SWITCH_TIMEOUT_MS));
         }
       } else if (bank === 'amex' && currentPhase === 'eligible') {
-        // All eligible cards done — transition to enrolled phase
+        // All eligible cards done — auto-transition to enrolled
         transitionToEnrolled();
       } else {
-        // All done (enrolled phase complete, or non-Amex bank)
+        // All done
         const total = syncedCardsRef.current.reduce((sum, c) => sum + c.count, 0);
         onSuccess(total, syncedCardsRef.current);
         onClose();
@@ -390,8 +378,7 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
   // ── Render ────────────────────────────────────────────────────
   const { cardName } = parseCardLabel(currentCard);
   const totalCards   = cardCount || 1;
-
-  const phaseLabel = syncPhaseUi === 'enrolled' ? 'activated' : 'eligible';
+  const phaseLabel   = syncPhaseUi === 'enrolled' ? 'activated' : 'eligible';
 
   const statusText = switching && syncPhaseRef.current === 'enrolled' && syncedCountRef.current === 0 && cardIndexRef.current === 0
     ? `⏳ Switching to activated offers...`
@@ -411,7 +398,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       );
     }
     if (onOffersPage) {
-      // Button only enabled when page is fully loaded
       const ready = pageLoaded;
       return (
         <TouchableOpacity
@@ -453,8 +439,8 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
             onNavigationStateChange={handleNavigationStateChange}
             onLoadEnd={handleLoadEnd}
             style={s.webview}
-            incognito={true}
-            sharedCookiesEnabled={false}
+            incognito={false}
+            sharedCookiesEnabled={true}
             thirdPartyCookiesEnabled={true}
           />
           <View style={s.footer}>

--- a/mobile/components/SyncWebView.js
+++ b/mobile/components/SyncWebView.js
@@ -9,18 +9,18 @@
 //   2. Page loaded, not on offers page  → "Go to Offers Page"
 //   3. Sync in progress                 → spinner + status
 //
-// onOffersPage source of truth per bank:
+// onOffersPage + pageLoaded source of truth per bank:
 //   Chase → CARDS_DETECTED message (SPA)
-//   Amex  → handleLoadEnd URL check via amexHandleLoadEnd()
-//           navState fires AFTER loadEnd on Amex so we skip the reset for Amex
+//   Amex  → handleLoadEnd ONLY via amexHandleLoadEnd()
+//           navState must NOT reset pageLoaded for Amex — navState fires
+//           after loadEnd and would wipe the flag before render
 //   Other → handleNavigationStateChange URL check
 //
 // Amex two-phase sync:
 //   Phase 1 (eligible) — user taps "Sync Offers"
 //   Phase 2 (enrolled) — auto after all eligible cards done
 //   Both phases use the same per-card switching + capture pipeline.
-//   Cookies/session persist across syncs (no incognito) so device trust is maintained.
-//   Entry URL always starts at login page — Amex auto-redirects if session is active.
+//   Cookies/session persist across syncs so device trust is maintained.
 //
 // Adding a new bank:
 //   1. Add entry to sync/bankConfig.js
@@ -55,10 +55,9 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
   const syncedCardsRef   = useRef([]);
   const cardsDiscovered  = useRef(false);
   const switchRetriesRef = useRef(0);
-  const syncedCountRef   = useRef(0);   // cards synced in current phase
+  const syncedCountRef   = useRef(0);
   const captureArmed     = useRef(false);
   const autoCapturing    = useRef(false);
-  // Amex two-phase: 'eligible' | 'enrolled'
   const syncPhaseRef     = useRef('eligible');
 
   // ── UI state ──────────────────────────────────────────────────
@@ -71,7 +70,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
   const [currentUrl, setCurrentUrl]     = useState('');
   const [cardCount, setCardCount]       = useState(0);
   const [cardIndexUi, setCardIndexUi]   = useState(0);
-  // Amex phase label for status text
   const [syncPhaseUi, setSyncPhaseUi]   = useState('eligible');
 
   const config = BANK_CONFIG[bank] || BANK_CONFIG.chase;
@@ -102,8 +100,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
   }, [visible]);
 
   // ── Helpers ───────────────────────────────────────────────────
-
-  // Reset per-card state when transitioning to a new sync phase.
   const resetForPhase = (phase) => {
     cardIndexRef.current     = 0;
     syncedCountRef.current   = 0;
@@ -116,7 +112,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
     setCardIndexUi(0);
     setSwitching(false);
     setSyncing(false);
-    // Keep cardOptionsRef — same cards, same order, just restart index
   };
 
   // ── Navigation handlers ───────────────────────────────────────
@@ -125,11 +120,13 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
     if (!navState.url) return;
     console.log(`[SyncWebView:${bank}] navState url:`, navState.url);
     setCurrentUrl(navState.url);
-    setPageLoaded(false);
 
-    // Amex: handleLoadEnd is the source of truth for onOffersPage.
+    // Amex: handleLoadEnd is the ONLY source of truth for pageLoaded + onOffersPage.
+    // navState fires AFTER loadEnd on Amex — resetting pageLoaded here would
+    // wipe the flag set by handleLoadEnd before the next render.
     if (config.useAmexCardSwitcher) return;
 
+    setPageLoaded(false);
     setOnOffersPage(false);
     if (!config.useCardsDetectedAsOffersSignal) {
       const url      = navState.url.toLowerCase();
@@ -150,7 +147,7 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
     }
 
     if (bank === 'amex') {
-      const { onOffersPage: onOffers, detectedPhase } = amexHandleLoadEnd({
+      const { onOffersPage: onOffers } = amexHandleLoadEnd({
         url,
         config,
         syncPhase:        syncPhaseRef.current,
@@ -170,7 +167,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
     webViewRef.current?.injectJavaScript(`window.location.replace('${target}'); true;`);
   };
 
-  // ── User taps "Sync Offers" (eligible phase only) ─────────────
   const handleSyncPress = () => {
     console.log(`[SyncWebView:${bank}] Sync pressed — gridSelector:`, config.gridSelector);
     setSyncStarted(true);
@@ -178,14 +174,12 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
     webViewRef.current?.injectJavaScript(buildCaptureJs(config.gridSelector, config.captureMaxBytes));
   };
 
-  // ── Transition from eligible → enrolled (Amex only) ──────────
   const transitionToEnrolled = () => {
     console.log('[SyncWebView:amex] transitioning to enrolled phase');
     resetForPhase('enrolled');
     webViewRef.current?.injectJavaScript(`window.location.replace('${config.enrolledUrl}'); true;`);
   };
 
-  // ── Auto-capture for enrolled phase ─────────────────────────
   const autoCapureEnrolledCard = () => {
     console.log('[SyncWebView:amex] auto-capturing enrolled card at index', cardIndexRef.current);
     captureArmed.current = true;
@@ -198,7 +192,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       const data = JSON.parse(event.nativeEvent.data);
       console.log(`[SyncWebView:${bank}] message type:`, data.type, data.error || '');
 
-      // ── Chase card detection ──────────────────────────────────
       if (data.type === 'CARDS_DETECTED') {
         const hasCards = data.cards?.length > 0;
         if (!cardsDiscovered.current && hasCards) {
@@ -214,11 +207,9 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         return;
       }
 
-      // ── Amex card detection ───────────────────────────────────
       if (data.type === 'AMEX_CARDS_DETECTED') {
         console.log('[SyncWebView:amex] AMEX_CARDS_DETECTED cards:', data.cards?.length, 'phase:', syncPhaseRef.current, 'error:', data.error);
         const hasCards = data.cards?.length > 0;
-
         if (!cardsDiscovered.current && hasCards) {
           if (syncPhaseRef.current === 'eligible') {
             cardOptionsRef.current = data.cards;
@@ -227,13 +218,11 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
             cardIndexRef.current = activeIdx >= 0 ? activeIdx : 0;
             setCardIndexUi(cardIndexRef.current);
           } else {
-            // enrolled: reuse stored card list, index already reset to 0
             setCardIndexUi(0);
           }
           cardsDiscovered.current = true;
           setCurrentCard(data.selectedLabel || null);
 
-          // enrolled phase: auto-switch to card 0 then capture
           if (syncPhaseRef.current === 'enrolled') {
             console.log('[SyncWebView:amex] enrolled cards detected — switching to card 0');
             const firstCard = cardOptionsRef.current[0];
@@ -248,7 +237,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         return;
       }
 
-      // ── Card switched (Chase + Amex) ──────────────────────────
       if (data.type === 'CARD_SWITCHED') {
         let switchConfirmed = false;
         if (bank === 'amex') {
@@ -281,7 +269,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
           return;
         }
 
-        // Eligible phase: delay before capture
         autoCapturing.current = true;
         setTimeout(() => {
           captureArmed.current  = true;
@@ -344,7 +331,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       setSyncing(false);
 
       if (syncedCountRef.current < totalCards) {
-        // More cards in this phase
         const nextPos = (cardIndexRef.current + 1) % totalCards;
         cardIndexRef.current = nextPos;
         setCardIndexUi(nextPos);
@@ -357,10 +343,8 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
           webViewRef.current?.injectJavaScript(buildSwitchCardJs(cardOptionsRef.current[nextPos].index, SWITCH_TIMEOUT_MS));
         }
       } else if (bank === 'amex' && currentPhase === 'eligible') {
-        // All eligible cards done — auto-transition to enrolled
         transitionToEnrolled();
       } else {
-        // All done
         const total = syncedCardsRef.current.reduce((sum, c) => sum + c.count, 0);
         onSuccess(total, syncedCardsRef.current);
         onClose();

--- a/mobile/components/SyncWebView.js
+++ b/mobile/components/SyncWebView.js
@@ -337,6 +337,20 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         return;
       }
 
+      // ── DEBUG_DUMP: log every Amex API call to disk (fired by amexSync.js for ALL calls) ──
+      if (data.type === 'DEBUG_DUMP' && bank === 'amex') {
+        console.log(`[SyncWebView:amex] DEBUG_DUMP label=${data.label}`);
+        fetch(`${API_BASE_URL}/api/debug/dump`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ label: data.label, data: data.data ?? null }),
+        })
+          .then(r => r.json())
+          .then(r => console.log('[SyncWebView:amex] DEBUG_DUMP wrote:', r.file))
+          .catch(e => console.log('[SyncWebView:amex] DEBUG_DUMP error:', e.message));
+        return;
+      }
+
       // ── Amex JSON capture ─────────────────────────────
       if (data.type === 'CAPTURE_JSON' && bank === 'amex') {
         console.log(`[SyncWebView:amex] CAPTURE_JSON — captureArmed=${captureArmed.current} cardLabel=${data.cardLabel}`);
@@ -345,16 +359,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
           return;
         }
         captureArmed.current = false;
-
-        // ── DEBUG: dump full raw response (no filtering) to api/debug-dumps/ ──
-        const cardLabel = data.cardLabel || 'unknown';
-        const safeLabel = cardLabel.replace(/[^a-z0-9]/gi, '_');
-        fetch(`${API_BASE_URL}/api/debug/dump`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ label: `rawResponse_${safeLabel}`, data: data.json ?? null }),
-        }).then(r => r.json()).then(r => console.log('[SyncWebView:amex] debug dump:', r.file));
-        // ─────────────────────────────────────────────────────────────────────
 
         const cards = cardOptionsRef.current;
         const capturedCard = cards.find(c =>

--- a/mobile/components/SyncWebView.js
+++ b/mobile/components/SyncWebView.js
@@ -41,11 +41,10 @@ const MAX_SWITCH_RETRIES   = 3;
 export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
   const webViewRef = useRef(null);
 
-  // ── Sync state refs ─────────────────────────────────────────────
-  const cardOptionsRef      = useRef([]);   // [{label, last4, testId, index, selected}]
-  const cardIndexRef        = useRef(0);    // current card index being synced
-  const visitedCardsRef     = useRef(new Set()); // testIds already captured this phase
-  const initialActiveRef    = useRef(null); // testId of card active when Sync was pressed
+  const cardOptionsRef      = useRef([]);
+  const cardIndexRef        = useRef(0);
+  const visitedCardsRef     = useRef(new Set());
+  const initialActiveRef    = useRef(null);
   const syncedCardsRef      = useRef([]);
   const cardsDiscovered     = useRef(false);
   const switchRetriesRef    = useRef(0);
@@ -54,7 +53,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
   const syncPhaseRef        = useRef('eligible');
   const pendingCardLabelRef = useRef(null);
 
-  // ── UI state ──────────────────────────────────────────────────
   const [syncing, setSyncing]               = useState(false);
   const [switching, setSwitching]           = useState(false);
   const [syncStarted, setSyncStarted]       = useState(false);
@@ -69,7 +67,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
 
   const config = BANK_CONFIG[bank] || BANK_CONFIG.chase;
 
-  // ── Reset on close ────────────────────────────────────────────
   useEffect(() => {
     if (!visible) {
       cardOptionsRef.current      = [];
@@ -97,7 +94,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
     }
   }, [visible]);
 
-  // ── Amex: switch to next unvisited card ──────────────────────────
   const switchToNextAmexCard = () => {
     const cards   = cardOptionsRef.current;
     const visited = visitedCardsRef.current;
@@ -117,7 +113,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
     return true;
   };
 
-  // ── Navigation handlers ───────────────────────────────────────
   const handleNavigationStateChange = (navState) => {
     if (!navState.url) return;
     console.log(`[SyncWebView:${bank}] navState url:`, navState.url);
@@ -167,7 +162,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
     webViewRef.current?.injectJavaScript(`window.location.replace('${target}'); true;`);
   };
 
-  // ── Sync press ────────────────────────────────────────────────
   const handleSyncPress = () => {
     console.log(`[SyncWebView:${bank}] Sync pressed — phase=${syncPhaseRef.current}`);
     setSyncStarted(true);
@@ -189,7 +183,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
     webViewRef.current?.injectJavaScript(buildCaptureJs(config.gridSelector, config.captureMaxBytes));
   };
 
-  // ── Shared post-capture logic ─────────────────────────────────
   const handleCaptureResult = async ({ payload, cardLabel, phase, capturedTestId }) => {
     setSyncing(true);
     const user = getAuthInstance().currentUser;
@@ -268,7 +261,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
     }
   };
 
-  // ── Message handler ───────────────────────────────────────────
   const handleMessage = async (event) => {
     try {
       const data = JSON.parse(event.nativeEvent.data);
@@ -354,13 +346,15 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         }
         captureArmed.current = false;
 
-        // ── DEBUG: log raw offersList as received from WebView ──
+        // ── DEBUG: dump raw offersList to api/debug-dumps/ ──
         const offersList = data.json?.recommendedOffers?.offersList;
-        if (offersList) {
-          console.log('[SyncWebView:amex] DEBUG recommendedOffers.offersList:', JSON.stringify(offersList));
-        } else {
-          console.log('[SyncWebView:amex] DEBUG recommendedOffers.offersList: missing');
-        }
+        const cardLabel  = data.cardLabel || 'unknown';
+        const safeLabel  = cardLabel.replace(/[^a-z0-9]/gi, '_');
+        fetch(`${API_BASE_URL}/api/debug/dump`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ label: `offersList_${safeLabel}`, data: offersList ?? null }),
+        }).then(r => r.json()).then(r => console.log('[SyncWebView:amex] debug dump:', r.file));
         // ───────────────────────────────────────────────────────
 
         const cards = cardOptionsRef.current;
@@ -402,7 +396,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
     }
   };
 
-  // ── Render ────────────────────────────────────────────────────
   const { cardName } = parseCardLabel(currentCard);
   const totalCards   = cardCount || 1;
   const phaseLabel   = syncPhaseUi === 'enrolled' ? 'activated' : 'eligible';

--- a/mobile/components/SyncWebView.js
+++ b/mobile/components/SyncWebView.js
@@ -314,7 +314,7 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       const response = await fetch(`${API_BASE_URL}/api/offers/parse`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
-        body: JSON.stringify({ html: data.html, bank, cardName: fullCardName }),
+        body: JSON.stringify({ html: data.html, bank, cardName: fullCardName, phase: syncPhaseRef.current }),
       });
       const result = await response.json();
       console.log(`[SyncWebView:${bank}] API response:`, JSON.stringify(result));

--- a/mobile/components/SyncWebView.js
+++ b/mobile/components/SyncWebView.js
@@ -53,16 +53,18 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
   const webViewRef = useRef(null);
 
   // ── Sync state refs (not UI) ──────────────────────────────────
-  const cardOptionsRef    = useRef([]);
-  const cardIndexRef      = useRef(0);
-  const syncedCardsRef    = useRef([]);
-  const cardsDiscovered   = useRef(false);
-  const switchRetriesRef  = useRef(0);
-  const syncedCountRef    = useRef(0);
-  const captureArmed      = useRef(false);
-  const syncPhaseRef      = useRef('eligible');
+  const cardOptionsRef      = useRef([]);
+  const cardIndexRef        = useRef(0);
+  const syncedCardsRef      = useRef([]);
+  const cardsDiscovered     = useRef(false);
+  const switchRetriesRef    = useRef(0);
+  const syncedCountRef      = useRef(0);
+  const captureArmed        = useRef(false);
+  const syncPhaseRef        = useRef('eligible');
   // After reload, switch to this card then capture
-  const switchPendingRef  = useRef(null); // { testId, cardIndex }
+  const switchPendingRef    = useRef(null); // { testId, cardIndex }
+  // Stores cardLabel from CARD_SWITCHED to avoid stale DOM read in CAPTURE_HTML
+  const pendingCardLabelRef = useRef(null);
 
   // ── UI state ──────────────────────────────────────────────────
   const [syncing, setSyncing]           = useState(false);
@@ -81,15 +83,16 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
   // ── Reset on close ────────────────────────────────────────────
   useEffect(() => {
     if (!visible) {
-      cardOptionsRef.current   = [];
-      cardIndexRef.current     = 0;
-      syncedCardsRef.current   = [];
-      cardsDiscovered.current  = false;
-      switchRetriesRef.current = 0;
-      syncedCountRef.current   = 0;
-      captureArmed.current     = false;
-      syncPhaseRef.current     = 'eligible';
-      switchPendingRef.current = null;
+      cardOptionsRef.current      = [];
+      cardIndexRef.current        = 0;
+      syncedCardsRef.current      = [];
+      cardsDiscovered.current     = false;
+      switchRetriesRef.current    = 0;
+      syncedCountRef.current      = 0;
+      captureArmed.current        = false;
+      syncPhaseRef.current        = 'eligible';
+      switchPendingRef.current    = null;
+      pendingCardLabelRef.current = null;
       setCurrentCard(null);
       setCurrentUrl('');
       setSyncing(false);
@@ -105,13 +108,14 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
 
   // ── Helpers ───────────────────────────────────────────────────
   const resetForPhase = (phase) => {
-    cardIndexRef.current     = 0;
-    syncedCountRef.current   = 0;
-    cardsDiscovered.current  = false;
-    switchRetriesRef.current = 0;
-    captureArmed.current     = false;
-    switchPendingRef.current = null;
-    syncPhaseRef.current     = phase;
+    cardIndexRef.current        = 0;
+    syncedCountRef.current      = 0;
+    cardsDiscovered.current     = false;
+    switchRetriesRef.current    = 0;
+    captureArmed.current        = false;
+    switchPendingRef.current    = null;
+    pendingCardLabelRef.current = null;
+    syncPhaseRef.current        = phase;
     setSyncPhaseUi(phase);
     setCardIndexUi(0);
     setSwitching(false);
@@ -255,6 +259,8 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         setCurrentCard(data.cardLabel || null);
 
         if (bank === 'amex') {
+          // Store label now — DOM may be stale by the time CAPTURE_HTML fires
+          pendingCardLabelRef.current = data.cardLabel || null;
           // Switch confirmed on fresh page — now capture
           console.log(`[SyncWebView:amex] switch confirmed (${data.cardLabel}) — arming capture`);
           setTimeout(() => {
@@ -298,7 +304,10 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       if (!user) throw new Error('You must be signed in to sync offers.');
       const token = await user.getIdToken();
 
-      const { cardName, cardLast4 } = parseCardLabel(data.cardLabel);
+      // Use pendingCardLabelRef if set (avoids stale DOM label after Amex card switch)
+      const resolvedLabel = pendingCardLabelRef.current || data.cardLabel;
+      pendingCardLabelRef.current = null;
+      const { cardName, cardLast4 } = parseCardLabel(resolvedLabel);
       const fullCardName = cardName
         ? (cardLast4 ? `${cardName} (...${cardLast4})` : cardName)
         : null;
@@ -347,8 +356,9 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         onClose();
       }
     } catch (err) {
-      captureArmed.current     = false;
-      switchPendingRef.current = null;
+      captureArmed.current        = false;
+      switchPendingRef.current    = null;
+      pendingCardLabelRef.current = null;
       setSyncing(false);
       setSwitching(false);
       console.error(`[SyncWebView:${bank}] handleMessage error:`, err.message);

--- a/mobile/components/SyncWebView.js
+++ b/mobile/components/SyncWebView.js
@@ -105,32 +105,25 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
     const visited = visitedCardsRef.current;
     const next = cards.find(c => !visited.has(c.testId) && c.testId !== initialActiveRef.current)
       ?? cards.find(c => !visited.has(c.testId));
-    if (!next) {
-      console.log('[SyncWebView:amex] all cards visited for phase', syncPhaseRef.current);
-      return false;
-    }
+    if (!next) return false;
+
     const idx = cards.indexOf(next);
     cardIndexRef.current = idx;
     setCardIndexUi(idx);
     setSwitching(true);
 
-    // IMPORTANT: arm BOTH the RN ref AND the window flag BEFORE injecting switch JS.
+    // Arm BOTH the RN ref AND the window flag BEFORE injecting switch JS.
     // Amex fires ReadOffersHubPresentation (REPLACE) immediately when the card
-    // switches — well before the CARD_SWITCHED message comes back from the timeout.
-    // If we wait to arm in CARD_SWITCHED, we miss the REPLACE and get stuck.
+    // switches — well before the CARD_SWITCHED message comes back.
     captureArmed.current = true;
     webViewRef.current?.injectJavaScript(`window.__amexJsonCaptureArmed = true; true;`);
-
-    // Clear any active filters so the full unfiltered offer set is returned.
     webViewRef.current?.injectJavaScript(buildAmexClearFiltersJs());
-    console.log(`[SyncWebView:amex] switching to card[${idx}] testId=${next.testId} (visited=${visited.size}/${cards.length})`);
     webViewRef.current?.injectJavaScript(buildAmexSwitchCardJs(next.testId, SWITCH_TIMEOUT_MS));
     return true;
   };
 
   const handleNavigationStateChange = (navState) => {
     if (!navState.url) return;
-    console.log(`[SyncWebView:${bank}] navState url:`, navState.url);
     setCurrentUrl(navState.url);
     if (config.useAmexCardSwitcher) return;
     setPageLoaded(false);
@@ -145,7 +138,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
 
   const handleLoadEnd = (syntheticEvent) => {
     const url = (syntheticEvent?.nativeEvent?.url || currentUrl).toLowerCase();
-    console.log(`[SyncWebView:${bank}] loadEnd url:`, url);
     setPageLoaded(true);
 
     if (bank === 'chase') {
@@ -164,23 +156,17 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       setOnOffersPage(onOffers);
       if (onOffers) {
         setAmexCardsReady(false);
-        console.log(`[SyncWebView:amex] (re)installing JSON interceptor on loadEnd (phase=${syncPhaseRef.current})`);
-        // Only installs/re-installs XHR+fetch interceptors — does NOT touch
-        // window.__amexJsonCaptureArmed. Arming is done in switchToNextAmexCard.
         webViewRef.current?.injectJavaScript(buildAmexJsonCaptureJs());
       }
-      return;
     }
   };
 
   const handleGoToOffers = () => {
     const target = config.offersUrl || config.url;
-    console.log(`[SyncWebView:${bank}] navigating to offersUrl:`, target);
     webViewRef.current?.injectJavaScript(`window.location.replace('${target}'); true;`);
   };
 
   const handleSyncPress = () => {
-    console.log(`[SyncWebView:${bank}] Sync pressed — phase=${syncPhaseRef.current}`);
     setSyncStarted(true);
 
     if (bank === 'amex') {
@@ -191,8 +177,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       }
       const activeCard = cards.find(c => c.selected) ?? cards[0];
       initialActiveRef.current = activeCard.testId;
-      console.log(`[SyncWebView:amex] sync start — active card: ${activeCard.label} (will capture last)`);
-      // Disarm before starting the cycle — switchToNextAmexCard will arm.
       webViewRef.current?.injectJavaScript(`window.__amexJsonCaptureArmed = false; true;`);
       switchToNextAmexCard();
       return;
@@ -218,14 +202,12 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       ? { json: payload, bank, cardName: fullCardName, phase }
       : { html: payload, bank, cardName: fullCardName, phase };
 
-    console.log(`[SyncWebView:${bank}] POSTing to ${API_BASE_URL}/api/offers/parse — phase=${phase} cardName=${fullCardName}`);
     const response = await fetch(`${API_BASE_URL}/api/offers/parse`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
       body: JSON.stringify(bodyObj),
     });
     const result = await response.json();
-    console.log(`[SyncWebView:${bank}] API response: synced=${result.synced} skipped=${result.skipped}`);
     if (!response.ok) throw new Error(result.error || 'Sync failed');
 
     syncedCardsRef.current = [
@@ -238,7 +220,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       if (capturedTestId) visitedCardsRef.current.add(capturedTestId);
       const totalCards = cardOptionsRef.current.length;
       const visited    = visitedCardsRef.current.size;
-      console.log(`[SyncWebView:amex] visited=${visited}/${totalCards} phase=${phase}`);
 
       if (visited < totalCards) {
         switchToNextAmexCard();
@@ -246,7 +227,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       }
 
       if (phase === 'eligible') {
-        console.log('[SyncWebView:amex] eligible phase complete — transitioning to enrolled');
         visitedCardsRef.current  = new Set();
         initialActiveRef.current = null;
         syncPhaseRef.current     = 'enrolled';
@@ -257,7 +237,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       }
 
       const total = syncedCardsRef.current.reduce((sum, c) => sum + c.count, 0);
-      console.log(`[SyncWebView:amex] all phases complete — total offers synced: ${total}`);
       onSuccess(total, syncedCardsRef.current);
       onClose();
       return;
@@ -283,11 +262,9 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
   const handleMessage = async (event) => {
     try {
       const data = JSON.parse(event.nativeEvent.data);
-      console.log(`[SyncWebView:${bank}] ✉️ message type=${data.type}`, data.error ? `error=${data.error}` : '');
 
       if (data.type === 'CARDS_DETECTED') {
         const hasCards = data.cards?.length > 0;
-        console.log(`[SyncWebView:chase] CARDS_DETECTED count=${data.cards?.length} selected=${data.selectedLabel}`);
         if (!cardsDiscovered.current && hasCards) {
           cardOptionsRef.current  = data.cards;
           cardsDiscovered.current = true;
@@ -303,24 +280,20 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
 
       if (data.type === 'AMEX_CARDS_DETECTED') {
         const hasCards = data.cards?.length > 0;
-        console.log(`[SyncWebView:amex] AMEX_CARDS_DETECTED count=${data.cards?.length} phase=${syncPhaseRef.current} alreadyDiscovered=${cardsDiscovered.current}`);
         if (!cardsDiscovered.current && hasCards && cardOptionsRef.current.length === 0) {
           cardOptionsRef.current = data.cards;
           setCardCount(data.cards.length);
           const activeIdx = data.cards.findIndex(c => c.selected);
           cardIndexRef.current = activeIdx >= 0 ? activeIdx : 0;
           setCardIndexUi(cardIndexRef.current);
-          console.log(`[SyncWebView:amex] stored ${data.cards.length} cards`);
         }
         if (!cardsDiscovered.current) cardsDiscovered.current = true;
         setCurrentCard(data.selectedLabel || null);
         if (hasCards) setAmexCardsReady(true);
 
         if (syncPhaseRef.current === 'enrolled' && syncStarted) {
-          console.log('[SyncWebView:amex] enrolled page ready — starting card cycle');
           const activeCard = data.cards?.find(c => c.selected) ?? cardOptionsRef.current[0];
           initialActiveRef.current = activeCard?.testId ?? null;
-          // Disarm before starting enrolled cycle — switchToNextAmexCard will arm.
           webViewRef.current?.injectJavaScript(`window.__amexJsonCaptureArmed = false; true;`);
           switchToNextAmexCard();
         }
@@ -328,18 +301,11 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       }
 
       if (data.type === 'CARD_SWITCHED') {
-        // For Amex: capture was already armed in switchToNextAmexCard before the
-        // switch JS was injected. CARD_SWITCHED just updates UI — no arming here.
-        console.log(`[SyncWebView:${bank}] CARD_SWITCHED cardLabel=${data.cardLabel}`);
         setSwitching(false);
         setCurrentCard(data.cardLabel || null);
         if (bank === 'amex') {
           pendingCardLabelRef.current = data.cardLabel || null;
-          // If CAPTURE_JSON already fired (common case), captureArmed is already
-          // false and CARD_SWITCHED is just informational. If it hasn't fired yet
-          // (slow network), window.__amexJsonCaptureArmed is still true — good.
         } else {
-          console.log(`[SyncWebView:chase] switch confirmed — capturing in ${POST_SWITCH_DELAY_MS}ms`);
           setTimeout(() => {
             captureArmed.current = true;
             webViewRef.current?.injectJavaScript(buildCaptureJs(config.gridSelector, config.captureMaxBytes));
@@ -349,7 +315,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       }
 
       if (data.type === 'CARD_SWITCH_ERROR') {
-        console.log(`[SyncWebView:${bank}] CARD_SWITCH_ERROR:`, data.message);
         setSwitching(false);
         captureArmed.current = false;
         webViewRef.current?.injectJavaScript(`window.__amexJsonCaptureArmed = false; true;`);
@@ -358,34 +323,15 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       }
 
       if (data.type === 'ERROR') {
-        console.log(`[SyncWebView:${bank}] ERROR from WebView:`, data.message);
         captureArmed.current = false;
         webViewRef.current?.injectJavaScript(`window.__amexJsonCaptureArmed = false; true;`);
         Alert.alert('Capture Error', data.message);
         return;
       }
 
-      // ── DEBUG_DUMP: log every Amex API call to disk ──
-      if (data.type === 'DEBUG_DUMP' && bank === 'amex') {
-        console.log(`[SyncWebView:amex] DEBUG_DUMP label=${data.label}`);
-        fetch(`${API_BASE_URL}/api/debug/dump`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ label: data.label, data: data.data ?? null }),
-        })
-          .then(r => r.json())
-          .then(r => console.log('[SyncWebView:amex] DEBUG_DUMP wrote:', r.file))
-          .catch(e => console.log('[SyncWebView:amex] DEBUG_DUMP error:', e.message));
-        return;
-      }
-
       // ── Amex JSON capture ─────────────────────────────────────
       if (data.type === 'CAPTURE_JSON' && bank === 'amex') {
-        console.log(`[SyncWebView:amex] CAPTURE_JSON — captureArmed=${captureArmed.current} cardLabel=${data.cardLabel}`);
-        if (!captureArmed.current) {
-          console.log('[SyncWebView:amex] CAPTURE_JSON ignored — not armed');
-          return;
-        }
+        if (!captureArmed.current) return;
         captureArmed.current = false;
 
         const cards = cardOptionsRef.current;
@@ -393,7 +339,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
           data.cardLabel && (c.label + (c.last4 ? ` (...${c.last4})` : '')) === data.cardLabel
         );
         const capturedTestId = capturedCard?.testId ?? null;
-        console.log(`[SyncWebView:amex] captured testId=${capturedTestId} label=${data.cardLabel}`);
 
         await handleCaptureResult({
           payload:         data.json,
@@ -405,12 +350,8 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       }
 
       // ── Chase HTML capture ────────────────────────────────────
-      if (data.type !== 'CAPTURE_HTML' || !captureArmed.current) {
-        console.log(`[SyncWebView:${bank}] ignoring message — type=${data.type} captureArmed=${captureArmed.current}`);
-        return;
-      }
+      if (data.type !== 'CAPTURE_HTML' || !captureArmed.current) return;
       captureArmed.current = false;
-      console.log(`[SyncWebView:chase] CAPTURE_HTML — html.length=${data.html?.length} cardLabel=${data.cardLabel}`);
       await handleCaptureResult({
         payload:   data.html,
         cardLabel: data.cardLabel,
@@ -423,7 +364,7 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       webViewRef.current?.injectJavaScript(`window.__amexJsonCaptureArmed = false; true;`);
       setSyncing(false);
       setSwitching(false);
-      console.error(`[SyncWebView:${bank}] handleMessage UNHANDLED ERROR:`, err.message);
+      console.error(`[SyncWebView] handleMessage error:`, err.message);
       Alert.alert('Sync Failed', err.message);
     }
   };

--- a/mobile/components/SyncWebView.js
+++ b/mobile/components/SyncWebView.js
@@ -1,49 +1,6 @@
 // ─────────────────────────────────────────────────────────────────
 // SYNC WEBVIEW MODAL — orchestrator
 // Handles modal UI, state, and message routing.
-// Bank-specific JS injection is in sync/ modules.
-//
-// Footer states:
-//   0. Not ready                        → nothing
-//   1. On offers page + page loaded     → "Sync Offers" button (enabled)
-//   2. Page loaded, not on offers page  → "Go to Offers Page"
-//   3. Sync in progress                 → spinner + status
-//
-// onOffersPage + pageLoaded source of truth per bank:
-//   Chase → CARDS_DETECTED message (SPA)
-//   Amex  → handleLoadEnd ONLY via amexHandleLoadEnd()
-//           navState must NOT reset pageLoaded for Amex — navState fires
-//           after loadEnd and would wipe the flag before render
-//   Other → handleNavigationStateChange URL check
-//
-// Amex two-phase sync:
-//   Phase 1 (eligible) — user taps "Sync Offers"
-//     → reloads the page; interceptor arms on loadEnd, catches API call
-//   Phase 2 (enrolled) — auto after all eligible cards done
-//     → same reload pattern
-//
-// Amex capture strategy:
-//   Instead of capturing DOM HTML, we inject buildAmexJsonCaptureJs()
-//   which intercepts the ReadOffersHubPresentation XHR/fetch response.
-//   The interceptor is armed on every loadEnd for Amex offers pages.
-//   On sync press we RELOAD the page — this triggers a fresh API call
-//   which the already-armed interceptor catches and posts as CAPTURE_JSON.
-//   We must NOT re-inject on sync press because the API call already fired
-//   on the initial page load; re-injecting just waits for a call that never comes.
-//   CAPTURE_JSON message is handled here; CAPTURE_HTML is Chase-only.
-//
-// Amex card switching strategy:
-//   After capturing card N, we reload the page fresh, THEN switch to card N+1.
-//   switchPendingRef holds the next card to switch to after reload.
-//   On loadEnd with switchPendingRef set: switch card, JSON interceptor
-//   will fire automatically when the card switch triggers a new API call.
-//
-// Chase is completely unchanged — still uses buildCaptureJs + CAPTURE_HTML.
-//
-// Adding a new bank:
-//   1. Add entry to sync/bankConfig.js
-//   2. Create sync/<bank>Sync.js with detect + switch JS
-//   3. Wire up in handleLoadEnd + handleMessage below
 // ─────────────────────────────────────────────────────────────────
 import React, { useRef, useState, useEffect } from 'react';
 import {
@@ -179,18 +136,8 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       setOnOffersPage(onOffers);
 
       if (onOffers) {
-        // Always arm interceptor on offers page load.
-        // On sync press we reload → this loadEnd fires again →
-        // interceptor re-arms → catches the fresh API call → CAPTURE_JSON.
-        console.log(`[SyncWebView:amex] arming JSON interceptor on loadEnd (phase=${syncPhaseRef.current} captureArmed=${captureArmed.current})`);
+        console.log(`[SyncWebView:amex] arming JSON interceptor on loadEnd (phase=${syncPhaseRef.current})`);
         webViewRef.current?.injectJavaScript(buildAmexJsonCaptureJs());
-      }
-
-      if (onOffers && switchPendingRef.current) {
-        const pending = switchPendingRef.current;
-        switchPendingRef.current = null;
-        console.log(`[SyncWebView:amex] page reloaded — switching to testId=${pending.testId} (cardIndex=${pending.cardIndex})`);
-        webViewRef.current?.injectJavaScript(buildAmexSwitchCardJs(pending.testId, SWITCH_TIMEOUT_MS));
       }
       return;
     }
@@ -202,21 +149,26 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
     webViewRef.current?.injectJavaScript(`window.location.replace('${target}'); true;`);
   };
 
-  // ── Sync press — bank-specific capture trigger ─────────────────
+  // ── Sync press ────────────────────────────────────────────────
   const handleSyncPress = () => {
     console.log(`[SyncWebView:${bank}] Sync pressed — phase=${syncPhaseRef.current}`);
     setSyncStarted(true);
     captureArmed.current = true;
 
     if (bank === 'amex') {
-      // Reload the page so Amex fires a fresh ReadOffersHubPresentation API call.
-      // The interceptor will be re-armed in handleLoadEnd (on the fresh load)
-      // and will catch that call automatically.
-      const reloadUrl = syncPhaseRef.current === 'enrolled'
-        ? config.enrolledUrl
-        : (config.offersUrl || config.url);
-      console.log(`[SyncWebView:amex] reloading ${reloadUrl} to trigger fresh API call`);
-      webViewRef.current?.injectJavaScript(`window.location.replace('${reloadUrl}'); true;`);
+      const cards      = cardOptionsRef.current;
+      const activeIdx  = cards.findIndex(c => c.selected);
+      // Switch to the first card that is NOT currently active
+      const nextIdx    = cards.findIndex((_, i) => i !== activeIdx);
+      if (nextIdx === -1) {
+        console.log('[SyncWebView:amex] only one card found — cannot switch');
+        Alert.alert('Only one card found', 'Cannot cycle cards to trigger API call.');
+        return;
+      }
+      const nextCard = cards[nextIdx];
+      cardIndexRef.current = nextIdx;
+      console.log(`[SyncWebView:amex] TEST — switching to card[${nextIdx}] testId=${nextCard.testId} to verify API fires`);
+      webViewRef.current?.injectJavaScript(buildAmexSwitchCardJs(nextCard.testId, SWITCH_TIMEOUT_MS));
       return;
     }
 
@@ -247,7 +199,7 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       ? { json: payload, bank, cardName: fullCardName, phase }
       : { html: payload, bank, cardName: fullCardName, phase };
 
-    console.log(`[SyncWebView:${bank}] handleCaptureResult — phase=${phase} cardName=${fullCardName} payloadType=${isAmex ? 'json' : 'html'} payloadSize=${isAmex ? JSON.stringify(payload).length : payload?.length}`);
+    console.log(`[SyncWebView:${bank}] handleCaptureResult — phase=${phase} cardName=${fullCardName} payloadSize=${isAmex ? JSON.stringify(payload).length : payload?.length}`);
     console.log(`[SyncWebView:${bank}] POSTing to ${API_BASE_URL}/api/offers/parse`);
 
     const response = await fetch(`${API_BASE_URL}/api/offers/parse`, {
@@ -256,7 +208,7 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       body: JSON.stringify(bodyObj),
     });
     const result = await response.json();
-    console.log(`[SyncWebView:${bank}] API /parse response:`, JSON.stringify(result));
+    console.log(`[SyncWebView:${bank}] API /parse response: synced=${result.synced} skipped=${result.skipped}`);
     if (!response.ok) throw new Error(result.error || 'Sync failed');
 
     syncedCardsRef.current = [
@@ -264,37 +216,9 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       { cardName: fullCardName || 'Unknown Card', count: result.synced ?? 0, phase },
     ];
     syncedCountRef.current += 1;
-
-    const totalCards = cardOptionsRef.current.length;
-    console.log(`[SyncWebView:${bank}] syncedCount=${syncedCountRef.current} totalCards=${totalCards} phase=${phase}`);
     setSyncing(false);
 
-    if (syncedCountRef.current < totalCards) {
-      const nextPos = (cardIndexRef.current + 1) % totalCards;
-      cardIndexRef.current = nextPos;
-      setCardIndexUi(nextPos);
-      setSwitching(true);
-      switchRetriesRef.current = 0;
-      cardsDiscovered.current  = false;
-
-      if (bank === 'amex') {
-        const nextCard  = cardOptionsRef.current[nextPos];
-        const reloadUrl = phase === 'enrolled' ? config.enrolledUrl : (config.offersUrl || config.url);
-        console.log(`[SyncWebView:amex] reloading ${reloadUrl} — will switch to testId=${nextCard.testId} after load`);
-        switchPendingRef.current = { testId: nextCard.testId, cardIndex: nextPos };
-        webViewRef.current?.injectJavaScript(`window.location.replace('${reloadUrl}'); true;`);
-      } else {
-        webViewRef.current?.injectJavaScript(buildSwitchCardJs(cardOptionsRef.current[nextPos].index, SWITCH_TIMEOUT_MS));
-      }
-    } else if (bank === 'amex' && phase === 'eligible') {
-      console.log('[SyncWebView:amex] all eligible cards done — transitioning to enrolled phase');
-      transitionToEnrolled();
-    } else {
-      const total = syncedCardsRef.current.reduce((sum, c) => sum + c.count, 0);
-      console.log(`[SyncWebView:${bank}] all phases done — total offers synced: ${total}`);
-      onSuccess(total, syncedCardsRef.current);
-      onClose();
-    }
+    console.log(`[SyncWebView:${bank}] ✅ captured card — syncedCount=${syncedCountRef.current} totalCards=${cardOptionsRef.current.length} phase=${phase}`);
   };
 
   // ── Message handler ───────────────────────────────────────────
@@ -334,53 +258,18 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         }
         if (!cardsDiscovered.current) cardsDiscovered.current = true;
         setCurrentCard(data.selectedLabel || null);
-
-        if (syncPhaseRef.current === 'enrolled' && !captureArmed.current) {
-          console.log('[SyncWebView:amex] enrolled page ready — arming captureArmed flag');
-          captureArmed.current = true;
-        }
         return;
       }
 
       // ── Card switched (Chase + Amex) ──────────────────
       if (data.type === 'CARD_SWITCHED') {
-        console.log(`[SyncWebView:${bank}] CARD_SWITCHED cardLabel=${data.cardLabel} expectedTestId=${data.expectedTestId || data.expectedIndex}`);
-        const switchConfirmed = bank === 'amex' ? !!data.cardLabel : (() => {
-          const expectedLabel = cardOptionsRef.current.find(c => c.index === data.expectedIndex)?.label || '';
-          const confirmed = expectedLabel ? data.cardLabel?.trim() === expectedLabel.trim() : !!data.cardLabel;
-          console.log(`[SyncWebView:chase] switch confirm: expected="${expectedLabel}" got="${data.cardLabel}" confirmed=${confirmed}`);
-          return confirmed;
-        })();
-
-        if (!switchConfirmed && switchRetriesRef.current < MAX_SWITCH_RETRIES) {
-          switchRetriesRef.current += 1;
-          const retryDelay = SWITCH_TIMEOUT_MS + switchRetriesRef.current * 1500;
-          console.log(`[SyncWebView:${bank}] switch not confirmed, retry ${switchRetriesRef.current}/${MAX_SWITCH_RETRIES} in ${retryDelay}ms`);
-          if (bank === 'amex') {
-            const card = cardOptionsRef.current[cardIndexRef.current];
-            webViewRef.current?.injectJavaScript(buildAmexSwitchCardJs(card.testId, retryDelay));
-          } else {
-            webViewRef.current?.injectJavaScript(buildSwitchCardJs(data.expectedIndex, retryDelay));
-          }
-          return;
-        }
-
-        switchRetriesRef.current = 0;
+        console.log(`[SyncWebView:${bank}] CARD_SWITCHED cardLabel=${data.cardLabel}`);
         setSwitching(false);
         setCurrentCard(data.cardLabel || null);
-
         if (bank === 'amex') {
           pendingCardLabelRef.current = data.cardLabel || null;
-          console.log(`[SyncWebView:amex] switch confirmed (${data.cardLabel}) — JSON interceptor will fire on next API call`);
-          return;
+          console.log(`[SyncWebView:amex] switch confirmed (${data.cardLabel}) — waiting for CAPTURE_JSON`);
         }
-
-        // Chase: capture after delay
-        console.log(`[SyncWebView:chase] switch confirmed — capturing HTML in ${POST_SWITCH_DELAY_MS}ms`);
-        setTimeout(() => {
-          captureArmed.current = true;
-          webViewRef.current?.injectJavaScript(buildCaptureJs(config.gridSelector, config.captureMaxBytes));
-        }, POST_SWITCH_DELAY_MS);
         return;
       }
 
@@ -401,17 +290,15 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
 
       // ── Amex JSON capture ─────────────────────────────
       if (data.type === 'CAPTURE_JSON' && bank === 'amex') {
-        console.log(`[SyncWebView:amex] CAPTURE_JSON received — captureArmed=${captureArmed.current} cardLabel=${data.cardLabel} jsonKeys=${Object.keys(data.json || {}).join(',')}`);
+        console.log(`[SyncWebView:amex] CAPTURE_JSON received — captureArmed=${captureArmed.current} cardLabel=${data.cardLabel}`);
         if (!captureArmed.current) {
           console.log('[SyncWebView:amex] CAPTURE_JSON ignored — not armed');
           return;
         }
         captureArmed.current = false;
-
         const resolvedLabel = pendingCardLabelRef.current || data.cardLabel;
         pendingCardLabelRef.current = null;
-        console.log(`[SyncWebView:amex] resolvedLabel=${resolvedLabel} phase=${syncPhaseRef.current}`);
-
+        console.log(`[SyncWebView:amex] ✅ CAPTURE_JSON confirmed — card switch DID trigger the API call!`);
         await handleCaptureResult({
           payload:   data.json,
           cardLabel: resolvedLabel,
@@ -427,10 +314,8 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       }
       captureArmed.current = false;
       console.log(`[SyncWebView:chase] CAPTURE_HTML received — html.length=${data.html?.length} cardLabel=${data.cardLabel}`);
-
       const resolvedLabel = pendingCardLabelRef.current || data.cardLabel;
       pendingCardLabelRef.current = null;
-
       await handleCaptureResult({
         payload:   data.html,
         cardLabel: resolvedLabel,
@@ -454,7 +339,7 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
   const phaseLabel   = syncPhaseUi === 'enrolled' ? 'activated' : 'eligible';
 
   const statusText = switching
-    ? `⏳ Switching card — reloading...`
+    ? `⏳ Switching card...`
     : syncing
       ? `🔄 Syncing ${phaseLabel} offers — ${cardName || 'card'} (${cardIndexUi + 1} of ${totalCards})...`
       : `⚡ Processing...`;

--- a/mobile/components/SyncWebView.js
+++ b/mobile/components/SyncWebView.js
@@ -55,16 +55,17 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
   const pendingCardLabelRef = useRef(null);
 
   // ── UI state ──────────────────────────────────────────────────
-  const [syncing, setSyncing]           = useState(false);
-  const [switching, setSwitching]       = useState(false);
-  const [syncStarted, setSyncStarted]   = useState(false);
-  const [pageLoaded, setPageLoaded]     = useState(false);
-  const [onOffersPage, setOnOffersPage] = useState(false);
-  const [currentCard, setCurrentCard]   = useState(null);
-  const [currentUrl, setCurrentUrl]     = useState('');
-  const [cardCount, setCardCount]       = useState(0);
-  const [cardIndexUi, setCardIndexUi]   = useState(0);
-  const [syncPhaseUi, setSyncPhaseUi]   = useState('eligible');
+  const [syncing, setSyncing]               = useState(false);
+  const [switching, setSwitching]           = useState(false);
+  const [syncStarted, setSyncStarted]       = useState(false);
+  const [pageLoaded, setPageLoaded]         = useState(false);
+  const [onOffersPage, setOnOffersPage]     = useState(false);
+  const [amexCardsReady, setAmexCardsReady] = useState(false); // true only after AMEX_CARDS_DETECTED fires with cards
+  const [currentCard, setCurrentCard]       = useState(null);
+  const [currentUrl, setCurrentUrl]         = useState('');
+  const [cardCount, setCardCount]           = useState(0);
+  const [cardIndexUi, setCardIndexUi]       = useState(0);
+  const [syncPhaseUi, setSyncPhaseUi]       = useState('eligible');
 
   const config = BANK_CONFIG[bank] || BANK_CONFIG.chase;
 
@@ -89,6 +90,7 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       setSyncStarted(false);
       setPageLoaded(false);
       setOnOffersPage(false);
+      setAmexCardsReady(false);
       setCardCount(0);
       setCardIndexUi(0);
       setSyncPhaseUi('eligible');
@@ -152,7 +154,9 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         injectJavaScript: (js) => webViewRef.current?.injectJavaScript(js),
       });
       setOnOffersPage(onOffers);
+      // Reset cards-ready on each new page load so button re-gates until detection completes
       if (onOffers) {
+        setAmexCardsReady(false);
         console.log(`[SyncWebView:amex] arming JSON interceptor on loadEnd (phase=${syncPhaseRef.current})`);
         webViewRef.current?.injectJavaScript(buildAmexJsonCaptureJs());
       }
@@ -312,6 +316,8 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         }
         if (!cardsDiscovered.current) cardsDiscovered.current = true;
         setCurrentCard(data.selectedLabel || null);
+        // Mark cards ready — Sync button will now be enabled
+        if (hasCards) setAmexCardsReady(true);
 
         // Enrolled phase: cards already known, start switching immediately
         if (syncPhaseRef.current === 'enrolled' && syncStarted) {
@@ -427,14 +433,17 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       );
     }
     if (onOffersPage) {
-      const ready = pageLoaded;
+      // For Amex: wait for card detection before enabling Sync button
+      const ready = pageLoaded && (bank === 'amex' ? amexCardsReady : true);
       return (
         <TouchableOpacity
           style={[s.syncBtn, !ready && s.syncBtnDisabled]}
           onPress={ready ? handleSyncPress : undefined}
           disabled={!ready}
         >
-          <Text style={s.syncBtnText}>{ready ? 'Sync Offers' : 'Loading...'}</Text>
+          <Text style={s.syncBtnText}>
+            {ready ? 'Sync Offers' : (bank === 'amex' && pageLoaded ? 'Detecting cards...' : 'Loading...')}
+          </Text>
         </TouchableOpacity>
       );
     }

--- a/mobile/components/SyncWebView.js
+++ b/mobile/components/SyncWebView.js
@@ -19,8 +19,11 @@
 // Amex two-phase sync:
 //   Phase 1 (eligible) — user taps "Sync Offers"
 //   Phase 2 (enrolled) — auto after all eligible cards done
-//   Both phases use the same per-card switching + capture pipeline.
-//   Cookies/session persist across syncs so device trust is maintained.
+//
+// Amex card switching strategy:
+//   After capturing a card, we switch via the dropdown THEN reload the page.
+//   This forces a fresh render with the new card's offers.
+//   On loadEnd, if reloadPendingCaptureRef is set we auto-arm capture.
 //
 // Adding a new bank:
 //   1. Add entry to sync/bankConfig.js
@@ -50,15 +53,17 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
   const webViewRef = useRef(null);
 
   // ── Sync state refs (not UI) ──────────────────────────────────
-  const cardOptionsRef   = useRef([]);
-  const cardIndexRef     = useRef(0);
-  const syncedCardsRef   = useRef([]);
-  const cardsDiscovered  = useRef(false);
-  const switchRetriesRef = useRef(0);
-  const syncedCountRef   = useRef(0);
-  const captureArmed     = useRef(false);
-  const autoCapturing    = useRef(false);
-  const syncPhaseRef     = useRef('eligible');
+  const cardOptionsRef          = useRef([]);
+  const cardIndexRef            = useRef(0);
+  const syncedCardsRef          = useRef([]);
+  const cardsDiscovered         = useRef(false);
+  const switchRetriesRef        = useRef(0);
+  const syncedCountRef          = useRef(0);
+  const captureArmed            = useRef(false);
+  const autoCapturing           = useRef(false);
+  const syncPhaseRef            = useRef('eligible');
+  // When true, the next loadEnd for this phase should auto-arm capture
+  const reloadPendingCaptureRef = useRef(false);
 
   // ── UI state ──────────────────────────────────────────────────
   const [syncing, setSyncing]           = useState(false);
@@ -77,15 +82,16 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
   // ── Reset on close ────────────────────────────────────────────
   useEffect(() => {
     if (!visible) {
-      cardOptionsRef.current   = [];
-      cardIndexRef.current     = 0;
-      syncedCardsRef.current   = [];
-      cardsDiscovered.current  = false;
-      switchRetriesRef.current = 0;
-      syncedCountRef.current   = 0;
-      captureArmed.current     = false;
-      autoCapturing.current    = false;
-      syncPhaseRef.current     = 'eligible';
+      cardOptionsRef.current          = [];
+      cardIndexRef.current            = 0;
+      syncedCardsRef.current          = [];
+      cardsDiscovered.current         = false;
+      switchRetriesRef.current        = 0;
+      syncedCountRef.current          = 0;
+      captureArmed.current            = false;
+      autoCapturing.current           = false;
+      syncPhaseRef.current            = 'eligible';
+      reloadPendingCaptureRef.current = false;
       setCurrentCard(null);
       setCurrentUrl('');
       setSyncing(false);
@@ -101,17 +107,27 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
 
   // ── Helpers ───────────────────────────────────────────────────
   const resetForPhase = (phase) => {
-    cardIndexRef.current     = 0;
-    syncedCountRef.current   = 0;
-    cardsDiscovered.current  = false;
-    switchRetriesRef.current = 0;
-    captureArmed.current     = false;
-    autoCapturing.current    = false;
-    syncPhaseRef.current     = phase;
+    cardIndexRef.current            = 0;
+    syncedCountRef.current          = 0;
+    cardsDiscovered.current         = false;
+    switchRetriesRef.current        = 0;
+    captureArmed.current            = false;
+    autoCapturing.current           = false;
+    reloadPendingCaptureRef.current = false;
+    syncPhaseRef.current            = phase;
     setSyncPhaseUi(phase);
     setCardIndexUi(0);
     setSwitching(false);
     setSyncing(false);
+  };
+
+  // Switch to next Amex card then reload the page so the offer list refreshes.
+  // On loadEnd, reloadPendingCaptureRef causes auto-capture of the fresh page.
+  const amexSwitchAndReload = (nextCard, pageUrl) => {
+    setSwitching(true);
+    switchRetriesRef.current = 0;
+    webViewRef.current?.injectJavaScript(buildAmexSwitchCardJs(nextCard.testId, SWITCH_TIMEOUT_MS));
+    // CARD_SWITCHED handler will set reloadPendingCaptureRef and reload
   };
 
   // ── Navigation handlers ───────────────────────────────────────
@@ -121,9 +137,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
     console.log(`[SyncWebView:${bank}] navState url:`, navState.url);
     setCurrentUrl(navState.url);
 
-    // Amex: handleLoadEnd is the ONLY source of truth for pageLoaded + onOffersPage.
-    // navState fires AFTER loadEnd on Amex — resetting pageLoaded here would
-    // wipe the flag set by handleLoadEnd before the next render.
     if (config.useAmexCardSwitcher) return;
 
     setPageLoaded(false);
@@ -155,10 +168,20 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         injectJavaScript: (js) => webViewRef.current?.injectJavaScript(js),
       });
       setOnOffersPage(onOffers);
+
+      // After a switch+reload, auto-arm capture on the freshly loaded page
+      if (onOffers && reloadPendingCaptureRef.current) {
+        console.log(`[SyncWebView:amex] reload complete — auto-arming capture (phase=${syncPhaseRef.current})`);
+        reloadPendingCaptureRef.current = false;
+        cardsDiscovered.current = false; // allow re-detection on fresh page
+        // Small delay to let the offer grid fully render
+        setTimeout(() => {
+          captureArmed.current = true;
+          webViewRef.current?.injectJavaScript(buildCaptureJs(config.gridSelector, config.captureMaxBytes));
+        }, POST_SWITCH_DELAY_MS);
+      }
       return;
     }
-
-    // Future banks: URL-based detection
   };
 
   const handleGoToOffers = () => {
@@ -178,12 +201,6 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
     console.log('[SyncWebView:amex] transitioning to enrolled phase');
     resetForPhase('enrolled');
     webViewRef.current?.injectJavaScript(`window.location.replace('${config.enrolledUrl}'); true;`);
-  };
-
-  const autoCapureEnrolledCard = () => {
-    console.log('[SyncWebView:amex] auto-capturing enrolled card at index', cardIndexRef.current);
-    captureArmed.current = true;
-    webViewRef.current?.injectJavaScript(buildCaptureJs(config.gridSelector, config.captureMaxBytes));
   };
 
   // ── Message handler ───────────────────────────────────────────
@@ -208,45 +225,29 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       }
 
       if (data.type === 'AMEX_CARDS_DETECTED') {
-        console.log('[SyncWebView:amex] AMEX_CARDS_DETECTED cards:', data.cards?.length, 'phase:', syncPhaseRef.current, 'error:', data.error);
+        console.log('[SyncWebView:amex] AMEX_CARDS_DETECTED cards:', data.cards?.length, 'phase:', syncPhaseRef.current);
         const hasCards = data.cards?.length > 0;
         if (!cardsDiscovered.current && hasCards) {
-          if (syncPhaseRef.current === 'eligible') {
+          // On eligible phase first load: store all cards for switching
+          // On enrolled phase or reloads: just pick up the current card label
+          if (syncPhaseRef.current === 'eligible' && cardOptionsRef.current.length === 0) {
             cardOptionsRef.current = data.cards;
             setCardCount(data.cards.length);
             const activeIdx = data.cards.findIndex(c => c.selected);
             cardIndexRef.current = activeIdx >= 0 ? activeIdx : 0;
             setCardIndexUi(cardIndexRef.current);
-          } else {
-            setCardIndexUi(0);
           }
           cardsDiscovered.current = true;
           setCurrentCard(data.selectedLabel || null);
-
-          if (syncPhaseRef.current === 'enrolled') {
-            console.log('[SyncWebView:amex] enrolled cards detected — switching to card 0');
-            const firstCard = cardOptionsRef.current[0];
-            if (firstCard) {
-              setSwitching(true);
-              webViewRef.current?.injectJavaScript(buildAmexSwitchCardJs(firstCard.testId, SWITCH_TIMEOUT_MS));
-            } else {
-              autoCapureEnrolledCard();
-            }
-          }
         }
         return;
       }
 
       if (data.type === 'CARD_SWITCHED') {
-        let switchConfirmed = false;
-        if (bank === 'amex') {
-          switchConfirmed = !!data.cardLabel;
-        } else {
+        const switchConfirmed = bank === 'amex' ? !!data.cardLabel : (() => {
           const expectedLabel = cardOptionsRef.current.find(c => c.index === data.expectedIndex)?.label || '';
-          switchConfirmed = expectedLabel
-            ? data.cardLabel?.trim() === expectedLabel.trim()
-            : !!data.cardLabel;
-        }
+          return expectedLabel ? data.cardLabel?.trim() === expectedLabel.trim() : !!data.cardLabel;
+        })();
 
         if (!switchConfirmed && switchRetriesRef.current < MAX_SWITCH_RETRIES) {
           switchRetriesRef.current += 1;
@@ -264,11 +265,17 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         setSwitching(false);
         setCurrentCard(data.cardLabel || null);
 
-        if (syncPhaseRef.current === 'enrolled') {
-          autoCapureEnrolledCard();
+        if (bank === 'amex') {
+          // Switch confirmed — reload the page so offer list is fresh
+          const reloadUrl = syncPhaseRef.current === 'enrolled' ? config.enrolledUrl : config.offersUrl || config.url;
+          console.log(`[SyncWebView:amex] switch confirmed, reloading ${reloadUrl} (phase=${syncPhaseRef.current})`);
+          reloadPendingCaptureRef.current = true;
+          cardsDiscovered.current = false;
+          webViewRef.current?.injectJavaScript(`window.location.replace('${reloadUrl}'); true;`);
           return;
         }
 
+        // Chase: capture after delay
         autoCapturing.current = true;
         setTimeout(() => {
           captureArmed.current  = true;
@@ -331,27 +338,31 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       setSyncing(false);
 
       if (syncedCountRef.current < totalCards) {
+        // More cards to sync in this phase — switch then reload
         const nextPos = (cardIndexRef.current + 1) % totalCards;
         cardIndexRef.current = nextPos;
         setCardIndexUi(nextPos);
-        setSwitching(true);
-        switchRetriesRef.current = 0;
         if (bank === 'amex') {
           const nextCard = cardOptionsRef.current[nextPos];
-          webViewRef.current?.injectJavaScript(buildAmexSwitchCardJs(nextCard.testId, SWITCH_TIMEOUT_MS));
+          amexSwitchAndReload(nextCard);
         } else {
+          setSwitching(true);
+          switchRetriesRef.current = 0;
           webViewRef.current?.injectJavaScript(buildSwitchCardJs(cardOptionsRef.current[nextPos].index, SWITCH_TIMEOUT_MS));
         }
       } else if (bank === 'amex' && currentPhase === 'eligible') {
+        // All eligible cards done — move to enrolled phase
         transitionToEnrolled();
       } else {
+        // All done
         const total = syncedCardsRef.current.reduce((sum, c) => sum + c.count, 0);
         onSuccess(total, syncedCardsRef.current);
         onClose();
       }
     } catch (err) {
-      captureArmed.current  = false;
-      autoCapturing.current = false;
+      captureArmed.current            = false;
+      autoCapturing.current           = false;
+      reloadPendingCaptureRef.current = false;
       setSyncing(false);
       setSwitching(false);
       console.error(`[SyncWebView:${bank}] handleMessage error:`, err.message);
@@ -364,13 +375,11 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
   const totalCards   = cardCount || 1;
   const phaseLabel   = syncPhaseUi === 'enrolled' ? 'activated' : 'eligible';
 
-  const statusText = switching && syncPhaseRef.current === 'enrolled' && syncedCountRef.current === 0 && cardIndexRef.current === 0
-    ? `⏳ Switching to activated offers...`
-    : switching
-      ? `⏳ Switching to card ${cardIndexUi + 1} of ${totalCards}...`
-      : syncing
-        ? `🔄 Syncing ${phaseLabel} offers — ${cardName || 'card'} (${cardIndexUi + 1} of ${totalCards})...`
-        : `⚡ Processing...`;
+  const statusText = switching
+    ? `⏳ Switching card — reloading offers...`
+    : syncing
+      ? `🔄 Syncing ${phaseLabel} offers — ${cardName || 'card'} (${cardIndexUi + 1} of ${totalCards})...`
+      : `⚡ Processing...`;
 
   const renderFooter = () => {
     if (syncStarted) {

--- a/mobile/components/SyncWebView.js
+++ b/mobile/components/SyncWebView.js
@@ -29,6 +29,7 @@ import {
   AMEX_OPEN_AND_DETECT_JS,
   buildAmexSwitchCardJs,
   buildAmexJsonCaptureJs,
+  buildAmexClearFiltersJs,
   amexHandleLoadEnd,
 } from './sync/amexSync.js';
 import { buildCaptureJs, parseCardLabel }                 from './sync/captureJs.js';
@@ -107,7 +108,12 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
     cardIndexRef.current = idx;
     setCardIndexUi(idx);
     setSwitching(true);
+    // Arm the capture BEFORE injecting the switch JS so the interceptor
+    // is ready when Amex fires ReadOffersHubPresentation after the switch.
     captureArmed.current = true;
+    // Fix 3: Clear any active filters so the full offer set is returned.
+    // Safe to call even with no filters active (no-op in that case).
+    webViewRef.current?.injectJavaScript(buildAmexClearFiltersJs());
     console.log(`[SyncWebView:amex] switching to card[${idx}] testId=${next.testId} (visited=${visited.size}/${cards.length})`);
     webViewRef.current?.injectJavaScript(buildAmexSwitchCardJs(next.testId, SWITCH_TIMEOUT_MS));
     return true;
@@ -150,6 +156,9 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       if (onOffers) {
         setAmexCardsReady(false);
         console.log(`[SyncWebView:amex] arming JSON interceptor on loadEnd (phase=${syncPhaseRef.current})`);
+        // NOTE: buildAmexJsonCaptureJs no longer auto-arms __amexJsonCaptureArmed.
+        // We only inject it here to install/re-install the XHR+fetch interceptors.
+        // Actual arming happens in switchToNextAmexCard via captureArmed ref.
         webViewRef.current?.injectJavaScript(buildAmexJsonCaptureJs());
       }
       return;
@@ -175,6 +184,9 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       const activeCard = cards.find(c => c.selected) ?? cards[0];
       initialActiveRef.current = activeCard.testId;
       console.log(`[SyncWebView:amex] sync start — active card: ${activeCard.label} (will capture last)`);
+      // Set window.__amexJsonCaptureArmed in the WebView to match captureArmed ref
+      // (switchToNextAmexCard sets captureArmed.current = true and the interceptor reads window.__amexJsonCaptureArmed)
+      webViewRef.current?.injectJavaScript(`window.__amexJsonCaptureArmed = false; true;`);
       switchToNextAmexCard();
       return;
     }
@@ -301,6 +313,7 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
           console.log('[SyncWebView:amex] enrolled page ready — starting card cycle');
           const activeCard = data.cards?.find(c => c.selected) ?? cardOptionsRef.current[0];
           initialActiveRef.current = activeCard?.testId ?? null;
+          webViewRef.current?.injectJavaScript(`window.__amexJsonCaptureArmed = false; true;`);
           switchToNextAmexCard();
         }
         return;
@@ -311,7 +324,10 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         setSwitching(false);
         setCurrentCard(data.cardLabel || null);
         if (bank === 'amex') {
+          // For Amex: captureArmed was set in switchToNextAmexCard.
+          // Now sync the window flag so the interceptor can fire.
           pendingCardLabelRef.current = data.cardLabel || null;
+          webViewRef.current?.injectJavaScript(`window.__amexJsonCaptureArmed = true; true;`);
         } else {
           console.log(`[SyncWebView:chase] switch confirmed — capturing in ${POST_SWITCH_DELAY_MS}ms`);
           setTimeout(() => {
@@ -326,6 +342,7 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         console.log(`[SyncWebView:${bank}] CARD_SWITCH_ERROR:`, data.message);
         setSwitching(false);
         captureArmed.current = false;
+        webViewRef.current?.injectJavaScript(`window.__amexJsonCaptureArmed = false; true;`);
         Alert.alert('Card Switch Failed', data.message);
         return;
       }
@@ -333,6 +350,7 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
       if (data.type === 'ERROR') {
         console.log(`[SyncWebView:${bank}] ERROR from WebView:`, data.message);
         captureArmed.current = false;
+        webViewRef.current?.injectJavaScript(`window.__amexJsonCaptureArmed = false; true;`);
         Alert.alert('Capture Error', data.message);
         return;
       }
@@ -351,7 +369,7 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         return;
       }
 
-      // ── Amex JSON capture ─────────────────────────────
+      // ── Amex JSON capture ─────────────────────────────────────
       if (data.type === 'CAPTURE_JSON' && bank === 'amex') {
         console.log(`[SyncWebView:amex] CAPTURE_JSON — captureArmed=${captureArmed.current} cardLabel=${data.cardLabel}`);
         if (!captureArmed.current) {
@@ -376,7 +394,7 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
         return;
       }
 
-      // ── Chase HTML capture ────────────────────────────
+      // ── Chase HTML capture ────────────────────────────────────
       if (data.type !== 'CAPTURE_HTML' || !captureArmed.current) {
         console.log(`[SyncWebView:${bank}] ignoring message — type=${data.type} captureArmed=${captureArmed.current}`);
         return;
@@ -392,6 +410,7 @@ export default function SyncWebView({ visible, bank, onClose, onSuccess }) {
     } catch (err) {
       captureArmed.current        = false;
       pendingCardLabelRef.current = null;
+      webViewRef.current?.injectJavaScript(`window.__amexJsonCaptureArmed = false; true;`);
       setSyncing(false);
       setSwitching(false);
       console.error(`[SyncWebView:${bank}] handleMessage UNHANDLED ERROR:`, err.message);

--- a/mobile/components/sync/amexSync.js
+++ b/mobile/components/sync/amexSync.js
@@ -148,6 +148,11 @@ export const AMEX_READ_CARD_LABEL_JS = `
 
 // ─────────────────────────────────────────────
 // buildAmexJsonCaptureJs
+// Intercepts ALL ReadOffersHubPresentation calls.
+// Every response is:
+//   1. Posted as CAPTURE_JSON to RN (only when armed, for actual sync)
+//   2. ALWAYS dumped to api/debug-dumps/ via DEBUG_DUMP message
+//      so we can see every call Amex makes and its full response.
 // ─────────────────────────────────────────────
 export const buildAmexJsonCaptureJs = () => `
   (function() {
@@ -155,6 +160,8 @@ export const buildAmexJsonCaptureJs = () => `
       console.log('[AmexCapture] buildAmexJsonCaptureJs called. currently armed:', !!window.__amexJsonCaptureArmed);
 
       window.__amexJsonCaptureArmed = true;
+
+      if (!window.__amexCallCounter) window.__amexCallCounter = 0;
 
       function readCardLabel() {
         var displayEl = document.querySelector('[data-testid="simple_switcher_selected_option_display"]');
@@ -169,37 +176,35 @@ export const buildAmexJsonCaptureJs = () => `
       }
 
       function fireCapture(jsonText, source) {
-        if (!window.__amexJsonCaptureArmed) {
-          console.log('[AmexCapture] fireCapture called but not armed (source=' + source + ') — ignoring');
-          return;
-        }
-        window.__amexJsonCaptureArmed = false;
+        var seq = ++window.__amexCallCounter;
         var cardLabel = readCardLabel();
-        console.log('[AmexCapture] fireCapture source=' + source + ' jsonText.length=' + jsonText.length + ' cardLabel=' + cardLabel);
+        console.log('[AmexCapture] fireCapture #' + seq + ' source=' + source + ' jsonText.length=' + jsonText.length + ' cardLabel=' + cardLabel + ' armed=' + window.__amexJsonCaptureArmed);
+
         try {
           var parsed = JSON.parse(jsonText);
-          console.log('[AmexCapture] parsed JSON top-level keys:', JSON.stringify(Object.keys(parsed)));
+          console.log('[AmexCapture] #' + seq + ' parsed JSON top-level keys:', JSON.stringify(Object.keys(parsed)));
 
-          if (parsed.recommendedOffers && parsed.recommendedOffers.offersList) {
-            console.log('[AmexCapture] recommendedOffers.offersList:', JSON.stringify(parsed.recommendedOffers.offersList));
-          } else {
-            console.log('[AmexCapture] recommendedOffers missing or no offersList');
-          }
-
-          if (parsed.addedToCard && parsed.addedToCard.offersList) {
-            console.log('[AmexCapture] addedToCard.offersList:', JSON.stringify(parsed.addedToCard.offersList));
-          } else {
-            console.log('[AmexCapture] addedToCard missing or no offersList');
-          }
-
-          console.log('[AmexCapture] posting CAPTURE_JSON to RN bridge');
+          // ── DEBUG: always dump every call regardless of armed state ──
+          var safeLabel = (cardLabel || 'unknown').replace(/[^a-z0-9]/gi, '_');
           window.ReactNativeWebView.postMessage(JSON.stringify({
-            type: 'CAPTURE_JSON',
-            json: parsed,
-            cardLabel: cardLabel,
+            type: 'DEBUG_DUMP',
+            label: 'ReadOffersHubPresentation_' + safeLabel + '_call' + seq,
+            data: parsed,
           }));
+          // ────────────────────────────────────────────────────────────
+
+          // Only forward to sync pipeline when armed
+          if (window.__amexJsonCaptureArmed) {
+            window.__amexJsonCaptureArmed = false;
+            console.log('[AmexCapture] #' + seq + ' posting CAPTURE_JSON to RN bridge');
+            window.ReactNativeWebView.postMessage(JSON.stringify({
+              type: 'CAPTURE_JSON',
+              json: parsed,
+              cardLabel: cardLabel,
+            }));
+          }
         } catch(e) {
-          console.log('[AmexCapture] JSON parse error:', e.message, 'first 200 chars:', jsonText.substring(0, 200));
+          console.log('[AmexCapture] #' + seq + ' JSON parse error:', e.message);
           window.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'ERROR',
             message: 'AmexCapture JSON parse error: ' + e.message,
@@ -225,7 +230,7 @@ export const buildAmexJsonCaptureJs = () => `
               console.log('[AmexCapture:XHR] ReadOffersHubPresentation detected, armed=', window.__amexJsonCaptureArmed);
               xhr.addEventListener('load', function() {
                 console.log('[AmexCapture:XHR] response status=' + xhr.status + ' responseText.length=' + (xhr.responseText || '').length);
-                if (xhr.status >= 200 && xhr.status < 300 && window.__amexJsonCaptureArmed) {
+                if (xhr.status >= 200 && xhr.status < 300) {
                   fireCapture(xhr.responseText, 'XHR');
                 }
               });
@@ -254,16 +259,14 @@ export const buildAmexJsonCaptureJs = () => `
           var p = origFetch.apply(window, arguments);
           if (url.includes('ReadOffersHubPresentation')) {
             p = p.then(function(response) {
-              console.log('[AmexCapture:fetch] ReadOffersHubPresentation response ok=' + response.ok + ' status=' + response.status);
+              console.log('[AmexCapture:fetch] response ok=' + response.ok + ' status=' + response.status);
               var cloned = response.clone();
               cloned.text().then(function(text) {
                 console.log('[AmexCapture:fetch] response body length=' + text.length);
-                if (response.ok && window.__amexJsonCaptureArmed) {
+                if (response.ok) {
                   fireCapture(text, 'fetch');
-                } else if (!response.ok) {
-                  console.log('[AmexCapture:fetch] response not ok, skipping capture');
                 } else {
-                  console.log('[AmexCapture:fetch] not armed, skipping capture');
+                  console.log('[AmexCapture:fetch] response not ok, skipping capture');
                 }
               });
               return response;

--- a/mobile/components/sync/amexSync.js
+++ b/mobile/components/sync/amexSync.js
@@ -19,6 +19,13 @@
 // IMPORTANT: enrolledPath is a substring of eligiblePath so we ALWAYS
 // check enrolled first and make them mutually exclusive.
 //
+// JSON capture strategy:
+//   Instead of capturing DOM HTML, we intercept the ReadOffersHubPresentation
+//   XHR/fetch response that Amex already fires when the page loads or when
+//   the card switcher changes the selected card.
+//   The interceptor is injected once on page load and posts CAPTURE_JSON
+//   when the next matching response arrives.
+//
 // Amex's SPA may auto-navigate to /offers/enrolled during eligible phase.
 // amexHandleLoadEnd gates injection on syncPhase match to ignore this.
 // ─────────────────────────────────────────────
@@ -127,6 +134,112 @@ export const AMEX_READ_CARD_LABEL_JS = `
     var last4     = numRaw.replace(/[^\\d]/g, '').slice(-4);
     return name + (last4 ? ' (...' + last4 + ')' : '');
   })()
+`;
+
+// ─────────────────────────────────────────────
+// buildAmexJsonCaptureJs
+//
+// Installs a one-shot XHR + fetch interceptor that listens for the
+// ReadOffersHubPresentation API response Amex fires on every page load
+// and card switch. When it fires, the raw JSON body is posted as
+// CAPTURE_JSON so SyncWebView can send it directly to the API instead
+// of sending DOM HTML.
+//
+// The interceptor fires once then removes itself (oneShot flag).
+// cardLabel is read from the combobox display at fire-time so the
+// label is always fresh.
+// ─────────────────────────────────────────────
+export const buildAmexJsonCaptureJs = () => `
+  (function() {
+    try {
+      if (window.__amexJsonCaptureArmed) {
+        console.log('[AmexCapture] already armed, skipping');
+        return;
+      }
+      window.__amexJsonCaptureArmed = true;
+
+      function readCardLabel() {
+        var displayEl = document.querySelector('[data-testid="simple_switcher_selected_option_display"]');
+        var nameEl    = displayEl ? displayEl.querySelector('[data-testid="simple_switcher_display_name"]') : null;
+        var numEl     = displayEl ? displayEl.querySelector('[data-testid="simple_switcher_display_number_val"]') : null;
+        var name      = nameEl ? nameEl.innerText.trim() : '';
+        var numRaw    = numEl  ? numEl.innerText.trim()  : '';
+        var last4     = numRaw.replace(/[^\\d]/g, '').slice(-4);
+        return name + (last4 ? ' (...' + last4 + ')' : '');
+      }
+
+      function fireCapture(jsonText) {
+        window.__amexJsonCaptureArmed = false;
+        var cardLabel = readCardLabel();
+        console.log('[AmexCapture] firing CAPTURE_JSON cardLabel=' + cardLabel);
+        try {
+          var parsed = JSON.parse(jsonText);
+          window.ReactNativeWebView.postMessage(JSON.stringify({
+            type: 'CAPTURE_JSON',
+            json: parsed,
+            cardLabel: cardLabel,
+          }));
+        } catch(e) {
+          window.ReactNativeWebView.postMessage(JSON.stringify({
+            type: 'ERROR',
+            message: 'AmexCapture JSON parse error: ' + e.message,
+          }));
+        }
+      }
+
+      // ── XHR interceptor ──────────────────────────────
+      var OrigXHR = window.XMLHttpRequest;
+      function PatchedXHR() {
+        var xhr = new OrigXHR();
+        var _url = '';
+        var origOpen = xhr.open.bind(xhr);
+        xhr.open = function(method, url) {
+          _url = url || '';
+          return origOpen.apply(xhr, arguments);
+        };
+        var origSend = xhr.send.bind(xhr);
+        xhr.send = function() {
+          if (_url.includes('ReadOffersHubPresentation') && window.__amexJsonCaptureArmed) {
+            xhr.addEventListener('load', function() {
+              if (xhr.status >= 200 && xhr.status < 300) {
+                console.log('[AmexCapture] XHR intercepted ReadOffersHubPresentation');
+                fireCapture(xhr.responseText);
+              }
+            });
+          }
+          return origSend.apply(xhr, arguments);
+        };
+        return xhr;
+      }
+      PatchedXHR.prototype = OrigXHR.prototype;
+      window.XMLHttpRequest = PatchedXHR;
+
+      // ── fetch interceptor ─────────────────────────────
+      var origFetch = window.fetch;
+      window.fetch = function(input, init) {
+        var url = (typeof input === 'string' ? input : (input && input.url)) || '';
+        var p = origFetch.apply(window, arguments);
+        if (url.includes('ReadOffersHubPresentation') && window.__amexJsonCaptureArmed) {
+          p = p.then(function(response) {
+            var cloned = response.clone();
+            cloned.text().then(function(text) {
+              if (response.ok) {
+                console.log('[AmexCapture] fetch intercepted ReadOffersHubPresentation');
+                fireCapture(text);
+              }
+            });
+            return response;
+          });
+        }
+        return p;
+      };
+
+      console.log('[AmexCapture] XHR+fetch interceptor armed');
+    } catch(e) {
+      window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'ERROR', message: 'AmexCapture setup error: ' + e.message }));
+    }
+  })();
+  true;
 `;
 
 // ─────────────────────────────────────────────

--- a/mobile/components/sync/amexSync.js
+++ b/mobile/components/sync/amexSync.js
@@ -85,10 +85,6 @@ export const AMEX_OPEN_AND_DETECT_JS = `
   true;
 `;
 
-// buildAmexSwitchCardJs
-// Tries to click the option matching testId (CARD_PRODUCT pattern, eligible page).
-// Falls back to first available [role="option"] if not found (enrolled page uses
-// numeric testIds that differ from eligible page testIds).
 export const buildAmexSwitchCardJs = (testId, timeoutMs = 3500) => `
   (function() {
     try {
@@ -152,22 +148,12 @@ export const AMEX_READ_CARD_LABEL_JS = `
 
 // ─────────────────────────────────────────────
 // buildAmexJsonCaptureJs
-//
-// Installs a one-shot XHR + fetch interceptor that listens for the
-// ReadOffersHubPresentation API response Amex fires on every page load
-// and card switch. When it fires, the raw JSON body is posted as
-// CAPTURE_JSON so SyncWebView can send it directly to the API instead
-// of sending DOM HTML.
-//
-// The interceptor fires once then removes itself (__amexJsonCaptureArmed flag).
-// cardLabel is read from the combobox display at fire-time.
 // ─────────────────────────────────────────────
 export const buildAmexJsonCaptureJs = () => `
   (function() {
     try {
       console.log('[AmexCapture] buildAmexJsonCaptureJs called. currently armed:', !!window.__amexJsonCaptureArmed);
 
-      // Always reset the flag so re-arming works after a previous capture
       window.__amexJsonCaptureArmed = true;
 
       function readCardLabel() {
@@ -194,23 +180,33 @@ export const buildAmexJsonCaptureJs = () => `
           var parsed = JSON.parse(jsonText);
           var topKeys = Object.keys(parsed);
           console.log('[AmexCapture] parsed JSON top-level keys:', JSON.stringify(topKeys));
-          // Log offer counts
-          var eligibleCount = 0;
-          var enrolledCount = 0;
+
           if (parsed.recommendedOffers && parsed.recommendedOffers.offersList) {
             var pages = Object.keys(parsed.recommendedOffers.offersList);
-            pages.forEach(function(p) { eligibleCount += (parsed.recommendedOffers.offersList[p] || []).length; });
-            console.log('[AmexCapture] recommendedOffers pages:', JSON.stringify(pages), 'total offers:', eligibleCount);
+            var titles = [];
+            pages.forEach(function(p) {
+              var pageOffers = parsed.recommendedOffers.offersList[p] || [];
+              pageOffers.forEach(function(o) { titles.push(o.title || '(no title)'); });
+            });
+            console.log('[AmexCapture] recommendedOffers pages:', JSON.stringify(pages), 'total:', titles.length);
+            console.log('[AmexCapture] recommendedOffers titles:', JSON.stringify(titles));
           } else {
             console.log('[AmexCapture] recommendedOffers missing or no offersList');
           }
+
           if (parsed.addedToCard && parsed.addedToCard.offersList) {
             var epages = Object.keys(parsed.addedToCard.offersList);
-            epages.forEach(function(p) { enrolledCount += (parsed.addedToCard.offersList[p] || []).length; });
-            console.log('[AmexCapture] addedToCard pages:', JSON.stringify(epages), 'total offers:', enrolledCount);
+            var etitles = [];
+            epages.forEach(function(p) {
+              var pageOffers = parsed.addedToCard.offersList[p] || [];
+              pageOffers.forEach(function(o) { etitles.push(o.title || '(no title)'); });
+            });
+            console.log('[AmexCapture] addedToCard pages:', JSON.stringify(epages), 'total:', etitles.length);
+            console.log('[AmexCapture] addedToCard titles:', JSON.stringify(etitles));
           } else {
             console.log('[AmexCapture] addedToCard missing or no offersList');
           }
+
           console.log('[AmexCapture] posting CAPTURE_JSON to RN bridge');
           window.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'CAPTURE_JSON',
@@ -226,8 +222,6 @@ export const buildAmexJsonCaptureJs = () => `
         }
       }
 
-      // ── XHR interceptor ──────────────────────────────
-      // Only patch once to avoid stacking interceptors on re-arm
       if (!window.__amexXhrPatched) {
         window.__amexXhrPatched = true;
         var OrigXHR = window.XMLHttpRequest;
@@ -262,7 +256,6 @@ export const buildAmexJsonCaptureJs = () => `
         console.log('[AmexCapture] XHR interceptor already installed, re-armed only');
       }
 
-      // ── fetch interceptor ─────────────────────────────
       if (!window.__amexFetchPatched) {
         window.__amexFetchPatched = true;
         var origFetch = window.fetch;
@@ -271,7 +264,6 @@ export const buildAmexJsonCaptureJs = () => `
           if (url.includes('ReadOffersHubPresentation')) {
             console.log('[AmexCapture:fetch] ReadOffersHubPresentation detected, armed=', window.__amexJsonCaptureArmed);
           } else {
-            // Log all fetch URLs at trace level so we know what APIs Amex calls
             console.log('[AmexCapture:fetch] url:', url.substring(0, 120));
           }
           var p = origFetch.apply(window, arguments);
@@ -308,18 +300,6 @@ export const buildAmexJsonCaptureJs = () => `
   true;
 `;
 
-// ─────────────────────────────────────────────
-// amexHandleLoadEnd
-// Call from SyncWebView.handleLoadEnd when bank === 'amex'.
-//
-// Returns:
-//   onOffersPage  — whether to show Sync Offers button
-//   detectedPhase — 'eligible' | 'enrolled' based on URL
-//
-// SyncWebView must only act on detectedPhase if it matches
-// the current syncPhaseRef. Amex SPA navigates to /enrolled
-// on its own during the eligible phase — we must ignore that.
-// ─────────────────────────────────────────────
 export const amexHandleLoadEnd = ({
   url,
   config,
@@ -333,14 +313,10 @@ export const amexHandleLoadEnd = ({
 
   const onLogin = (config.loginPaths || []).some(p => lower.includes(p.toLowerCase()));
 
-  // Check enrolled FIRST — enrolled path is a substring of eligible path
   const onEnrolled = !onLogin && lower.includes(enrolledPathLower);
-  // Eligible must explicitly exclude enrolled
   const onEligible = !onLogin && !onEnrolled && lower.includes(eligiblePathLower);
 
   const detectedPhase = onEnrolled ? 'enrolled' : 'eligible';
-
-  // Gate on phase match to ignore Amex SPA auto-navigation to /enrolled
   const phaseMatch   = detectedPhase === syncPhase;
   const onOffersPage = phaseMatch && (onEligible || onEnrolled);
 

--- a/mobile/components/sync/amexSync.js
+++ b/mobile/components/sync/amexSync.js
@@ -3,28 +3,24 @@
 //
 // Amex uses a combobox + listbox pattern:
 //   [data-testid="simple_switcher_combobox"]
-//   [role="option"][data-testid*="CARD_PRODUCT"]
+//   [role="option"][data-testid*="CARD_PRODUCT"]  ← eligible page
+//   [role="option"]                               ← enrolled page (numeric testIds)
 //
 // Card switching:
 //   1. Click combobox to open listbox
-//   2. Click the target option by data-testid
-//   3. Wait for re-render, then confirm via display label
-//
-// CARD_PRODUCT filter excludes checking/savings accounts.
+//   2. Click target option by data-testid (CARD_PRODUCT)
+//      OR fall back to first [role="option"] (enrolled page uses numeric testIds)
+//   3. Wait for re-render, confirm via display label
 //
 // Two-phase sync:
-//   Phase 1 (eligible)  → global.americanexpress.com/offers (with query params)
+//   Phase 1 (eligible)  → global.americanexpress.com/offers
 //   Phase 2 (enrolled)  → global.americanexpress.com/offers/enrolled
 //
 // IMPORTANT: enrolledPath is a substring of eligiblePath so we ALWAYS
 // check enrolled first and make them mutually exclusive.
 //
 // Amex's SPA may auto-navigate to /offers/enrolled during eligible phase.
-// amexHandleLoadEnd returns detectedPhase so SyncWebView can ignore it
-// when syncPhase is still 'eligible'.
-//
-// All Amex-specific URL detection logic lives in amexHandleLoadEnd()
-// so SyncWebView stays bank-agnostic.
+// amexHandleLoadEnd gates injection on syncPhase match to ignore this.
 // ─────────────────────────────────────────────
 
 const DETECT_CARDS_INNER = `
@@ -32,13 +28,13 @@ const DETECT_CARDS_INNER = `
     var options = document.querySelectorAll('[role="option"][data-testid*="CARD_PRODUCT"]');
     var cards = [];
     options.forEach(function(opt, i) {
-      var nameEl  = opt.querySelector('[data-testid="simple_switcher_display_name"]');
-      var numEl   = opt.querySelector('[data-testid="simple_switcher_display_number_val"]');
-      var name    = nameEl ? nameEl.innerText.trim() : '';
-      var numRaw  = numEl  ? numEl.innerText.trim()  : '';
-      var last4   = numRaw.replace(/[^\\d]/g, '').slice(-4);
+      var nameEl   = opt.querySelector('[data-testid="simple_switcher_display_name"]');
+      var numEl    = opt.querySelector('[data-testid="simple_switcher_display_number_val"]');
+      var name     = nameEl ? nameEl.innerText.trim() : '';
+      var numRaw   = numEl  ? numEl.innerText.trim()  : '';
+      var last4    = numRaw.replace(/[^\\d]/g, '').slice(-4);
       var selected = opt.getAttribute('aria-selected') === 'true';
-      var testId  = opt.getAttribute('data-testid') || '';
+      var testId   = opt.getAttribute('data-testid') || '';
       cards.push({ label: name, last4: last4, testId: testId, index: i, selected: selected });
     });
     var selectedCard = cards.find(function(c) { return c.selected; });
@@ -74,6 +70,10 @@ export const AMEX_OPEN_AND_DETECT_JS = `
   true;
 `;
 
+// buildAmexSwitchCardJs
+// Tries to click the option matching testId (CARD_PRODUCT pattern, eligible page).
+// Falls back to first available [role="option"] if not found (enrolled page uses
+// numeric testIds that differ from eligible page testIds).
 export const buildAmexSwitchCardJs = (testId, timeoutMs = 3500) => `
   (function() {
     try {
@@ -84,9 +84,14 @@ export const buildAmexSwitchCardJs = (testId, timeoutMs = 3500) => `
       }
       combobox.click();
       setTimeout(function() {
+        // Try exact testId match first (eligible page CARD_PRODUCT pattern)
         var option = document.querySelector('[data-testid="${testId}"]');
+        // Fallback: first available [role="option"] (enrolled page numeric testIds)
         if (!option) {
-          window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'CARD_SWITCH_ERROR', message: 'Amex option not found: ${testId}' }));
+          option = document.querySelector('[role="option"]');
+        }
+        if (!option) {
+          window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'CARD_SWITCH_ERROR', message: 'No switchable option found for: ${testId}' }));
           return;
         }
         option.click();
@@ -154,12 +159,9 @@ export const amexHandleLoadEnd = ({
   // Eligible must explicitly exclude enrolled
   const onEligible = !onLogin && !onEnrolled && lower.includes(eligiblePathLower);
 
-  // detectedPhase is purely URL-based
   const detectedPhase = onEnrolled ? 'enrolled' : 'eligible';
 
-  // onOffersPage only true when detectedPhase matches the current sync phase.
-  // This prevents Amex's own SPA navigation to /enrolled from showing
-  // the Sync button or injecting card detection during the eligible phase.
+  // Gate on phase match to ignore Amex SPA auto-navigation to /enrolled
   const phaseMatch   = detectedPhase === syncPhase;
   const onOffersPage = phaseMatch && (onEligible || onEnrolled);
 
@@ -168,7 +170,6 @@ export const amexHandleLoadEnd = ({
     `syncPhase=${syncPhase} detectedPhase=${detectedPhase} phaseMatch=${phaseMatch} cardsDiscovered=${cardsDiscovered}`
   );
 
-  // Only inject card detection when phase matches and cards not yet found
   if (onOffersPage && !cardsDiscovered) {
     console.log('[amexHandleLoadEnd] injecting AMEX_OPEN_AND_DETECT_JS');
     injectJavaScript(AMEX_OPEN_AND_DETECT_JS);

--- a/mobile/components/sync/amexSync.js
+++ b/mobile/components/sync/amexSync.js
@@ -13,8 +13,15 @@
 // CARD_PRODUCT filter excludes checking/savings accounts.
 //
 // Two-phase sync:
-//   Phase 1 (eligible)  → global.americanexpress.com/offers/eligible
+//   Phase 1 (eligible)  → global.americanexpress.com/offers (with query params)
 //   Phase 2 (enrolled)  → global.americanexpress.com/offers/enrolled
+//
+// IMPORTANT: enrolledPath is a substring of eligiblePath so we ALWAYS
+// check enrolled first and make them mutually exclusive.
+//
+// Amex's SPA may auto-navigate to /offers/enrolled during eligible phase.
+// amexHandleLoadEnd returns detectedPhase so SyncWebView can ignore it
+// when syncPhase is still 'eligible'.
 //
 // All Amex-specific URL detection logic lives in amexHandleLoadEnd()
 // so SyncWebView stays bank-agnostic.
@@ -105,7 +112,6 @@ export const buildAmexSwitchCardJs = (testId, timeoutMs = 3500) => `
   true;
 `;
 
-// Read current card label from Amex combobox display
 export const AMEX_READ_CARD_LABEL_JS = `
   (function() {
     var displayEl = document.querySelector('[data-testid="simple_switcher_selected_option_display"]');
@@ -120,38 +126,49 @@ export const AMEX_READ_CARD_LABEL_JS = `
 
 // ─────────────────────────────────────────────
 // amexHandleLoadEnd
-// Call this from SyncWebView.handleLoadEnd when bank === 'amex'.
-// Returns { onOffersPage, phase } so SyncWebView can update state.
-// Also triggers card detection injection when appropriate.
+// Call from SyncWebView.handleLoadEnd when bank === 'amex'.
 //
-// phases: 'eligible' | 'enrolled'
+// Returns:
+//   onOffersPage  — whether to show Sync Offers button
+//   detectedPhase — 'eligible' | 'enrolled' based on URL
+//
+// SyncWebView must only act on detectedPhase if it matches
+// the current syncPhaseRef. Amex SPA navigates to /enrolled
+// on its own during the eligible phase — we must ignore that.
 // ─────────────────────────────────────────────
 export const amexHandleLoadEnd = ({
   url,
   config,
-  syncPhase,          // current phase ref value
-  cardsDiscovered,    // ref.current
-  injectJavaScript,   // webViewRef.current?.injectJavaScript
+  syncPhase,
+  cardsDiscovered,
+  injectJavaScript,
 }) => {
   const lower = url.toLowerCase();
+  const enrolledPathLower = config.enrolledPath.toLowerCase();
+  const eligiblePathLower = config.eligiblePath.toLowerCase();
+
   const onLogin = (config.loginPaths || []).some(p => lower.includes(p.toLowerCase()));
 
-  const onEligible = !onLogin && lower.includes(config.eligiblePath.toLowerCase());
-  const onEnrolled = !onLogin && lower.includes(config.enrolledPath.toLowerCase());
-  const onOffersPage = onEligible || onEnrolled;
+  // Check enrolled FIRST — enrolled path is a substring of eligible path
+  const onEnrolled = !onLogin && lower.includes(enrolledPathLower);
+  // Eligible must explicitly exclude enrolled
+  const onEligible = !onLogin && !onEnrolled && lower.includes(eligiblePathLower);
 
-  // Determine phase from URL — URL is source of truth
+  // detectedPhase is purely URL-based
   const detectedPhase = onEnrolled ? 'enrolled' : 'eligible';
+
+  // onOffersPage only true when detectedPhase matches the current sync phase.
+  // This prevents Amex's own SPA navigation to /enrolled from showing
+  // the Sync button or injecting card detection during the eligible phase.
+  const phaseMatch   = detectedPhase === syncPhase;
+  const onOffersPage = phaseMatch && (onEligible || onEnrolled);
 
   console.log(
     `[amexHandleLoadEnd] onLogin=${onLogin} onEligible=${onEligible} onEnrolled=${onEnrolled}`,
-    `syncPhase=${syncPhase} detectedPhase=${detectedPhase} cardsDiscovered=${cardsDiscovered}`
+    `syncPhase=${syncPhase} detectedPhase=${detectedPhase} phaseMatch=${phaseMatch} cardsDiscovered=${cardsDiscovered}`
   );
 
-  // Inject card detection when:
-  // - we are on an offers page
-  // - cards not yet discovered for this phase
-  //   (cardsDiscovered resets to false when phase transitions)
+  // Only inject card detection when phase matches and cards not yet found
   if (onOffersPage && !cardsDiscovered) {
     console.log('[amexHandleLoadEnd] injecting AMEX_OPEN_AND_DETECT_JS');
     injectJavaScript(AMEX_OPEN_AND_DETECT_JS);

--- a/mobile/components/sync/amexSync.js
+++ b/mobile/components/sync/amexSync.js
@@ -33,6 +33,7 @@
 const DETECT_CARDS_INNER = `
   (function detectAmexCards() {
     var options = document.querySelectorAll('[role="option"][data-testid*="CARD_PRODUCT"]');
+    console.log('[AmexDetect] CARD_PRODUCT options found:', options.length);
     var cards = [];
     options.forEach(function(opt, i) {
       var nameEl   = opt.querySelector('[data-testid="simple_switcher_display_name"]');
@@ -42,9 +43,11 @@ const DETECT_CARDS_INNER = `
       var last4    = numRaw.replace(/[^\\d]/g, '').slice(-4);
       var selected = opt.getAttribute('aria-selected') === 'true';
       var testId   = opt.getAttribute('data-testid') || '';
+      console.log('[AmexDetect] card[' + i + '] name=' + name + ' last4=' + last4 + ' selected=' + selected + ' testId=' + testId);
       cards.push({ label: name, last4: last4, testId: testId, index: i, selected: selected });
     });
     var selectedCard = cards.find(function(c) { return c.selected; });
+    console.log('[AmexDetect] posting AMEX_CARDS_DETECTED count=' + cards.length + ' selected=' + (selectedCard ? selectedCard.label : 'none'));
     window.ReactNativeWebView.postMessage(JSON.stringify({
       type: 'AMEX_CARDS_DETECTED',
       cards: cards,
@@ -56,21 +59,26 @@ const DETECT_CARDS_INNER = `
 export const AMEX_OPEN_AND_DETECT_JS = `
   (function() {
     try {
+      console.log('[AmexDetect] AMEX_OPEN_AND_DETECT_JS running');
       var combobox = document.querySelector('[data-testid="simple_switcher_combobox"]');
+      console.log('[AmexDetect] combobox found:', !!combobox);
       if (!combobox) {
         window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'AMEX_CARDS_DETECTED', cards: [], selectedLabel: '', error: 'Combobox not found' }));
         return;
       }
       var alreadyOpen = combobox.getAttribute('aria-expanded') === 'true';
+      console.log('[AmexDetect] combobox alreadyOpen:', alreadyOpen);
       if (alreadyOpen) {
         ${DETECT_CARDS_INNER}
         return;
       }
       combobox.click();
+      console.log('[AmexDetect] combobox clicked, waiting 600ms for listbox...');
       setTimeout(function() {
         ${DETECT_CARDS_INNER}
       }, 600);
     } catch(e) {
+      console.log('[AmexDetect] ERROR:', e.message);
       window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'AMEX_CARDS_DETECTED', cards: [], selectedLabel: '', error: e.message }));
     }
   })();
@@ -84,24 +92,28 @@ export const AMEX_OPEN_AND_DETECT_JS = `
 export const buildAmexSwitchCardJs = (testId, timeoutMs = 3500) => `
   (function() {
     try {
+      console.log('[AmexSwitch] buildAmexSwitchCardJs running for testId=${testId} timeout=${timeoutMs}ms');
       var combobox = document.querySelector('[data-testid="simple_switcher_combobox"]');
+      console.log('[AmexSwitch] combobox found:', !!combobox);
       if (!combobox) {
         window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'CARD_SWITCH_ERROR', message: 'Amex combobox not found' }));
         return;
       }
       combobox.click();
+      console.log('[AmexSwitch] combobox clicked, waiting 600ms...');
       setTimeout(function() {
-        // Try exact testId match first (eligible page CARD_PRODUCT pattern)
         var option = document.querySelector('[data-testid="${testId}"]');
-        // Fallback: first available [role="option"] (enrolled page numeric testIds)
+        console.log('[AmexSwitch] exact testId match found:', !!option);
         if (!option) {
           option = document.querySelector('[role="option"]');
+          console.log('[AmexSwitch] fallback [role=option] found:', !!option);
         }
         if (!option) {
           window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'CARD_SWITCH_ERROR', message: 'No switchable option found for: ${testId}' }));
           return;
         }
         option.click();
+        console.log('[AmexSwitch] option clicked, waiting ${timeoutMs}ms for re-render...');
         setTimeout(function() {
           var displayEl = document.querySelector('[data-testid="simple_switcher_selected_option_display"]');
           var nameEl    = displayEl ? displayEl.querySelector('[data-testid="simple_switcher_display_name"]') : null;
@@ -110,6 +122,7 @@ export const buildAmexSwitchCardJs = (testId, timeoutMs = 3500) => `
           var numRaw    = numEl  ? numEl.innerText.trim()  : '';
           var last4     = numRaw.replace(/[^\\d]/g, '').slice(-4);
           var cardLabel = name + (last4 ? ' (...' + last4 + ')' : '');
+          console.log('[AmexSwitch] CARD_SWITCHED cardLabel=' + cardLabel + ' expectedTestId=${testId}');
           window.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'CARD_SWITCHED',
             cardLabel: cardLabel,
@@ -118,6 +131,7 @@ export const buildAmexSwitchCardJs = (testId, timeoutMs = 3500) => `
         }, ${timeoutMs});
       }, 600);
     } catch(e) {
+      console.log('[AmexSwitch] ERROR:', e.message);
       window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'CARD_SWITCH_ERROR', message: e.message }));
     }
   })();
@@ -145,17 +159,15 @@ export const AMEX_READ_CARD_LABEL_JS = `
 // CAPTURE_JSON so SyncWebView can send it directly to the API instead
 // of sending DOM HTML.
 //
-// The interceptor fires once then removes itself (oneShot flag).
-// cardLabel is read from the combobox display at fire-time so the
-// label is always fresh.
+// The interceptor fires once then removes itself (__amexJsonCaptureArmed flag).
+// cardLabel is read from the combobox display at fire-time.
 // ─────────────────────────────────────────────
 export const buildAmexJsonCaptureJs = () => `
   (function() {
     try {
-      if (window.__amexJsonCaptureArmed) {
-        console.log('[AmexCapture] already armed, skipping');
-        return;
-      }
+      console.log('[AmexCapture] buildAmexJsonCaptureJs called. currently armed:', !!window.__amexJsonCaptureArmed);
+
+      // Always reset the flag so re-arming works after a previous capture
       window.__amexJsonCaptureArmed = true;
 
       function readCardLabel() {
@@ -165,21 +177,48 @@ export const buildAmexJsonCaptureJs = () => `
         var name      = nameEl ? nameEl.innerText.trim() : '';
         var numRaw    = numEl  ? numEl.innerText.trim()  : '';
         var last4     = numRaw.replace(/[^\\d]/g, '').slice(-4);
-        return name + (last4 ? ' (...' + last4 + ')' : '');
+        var label     = name + (last4 ? ' (...' + last4 + ')' : '');
+        console.log('[AmexCapture] readCardLabel =', label || '(empty)');
+        return label;
       }
 
-      function fireCapture(jsonText) {
+      function fireCapture(jsonText, source) {
+        if (!window.__amexJsonCaptureArmed) {
+          console.log('[AmexCapture] fireCapture called but not armed (source=' + source + ') — ignoring');
+          return;
+        }
         window.__amexJsonCaptureArmed = false;
         var cardLabel = readCardLabel();
-        console.log('[AmexCapture] firing CAPTURE_JSON cardLabel=' + cardLabel);
+        console.log('[AmexCapture] fireCapture source=' + source + ' jsonText.length=' + jsonText.length + ' cardLabel=' + cardLabel);
         try {
           var parsed = JSON.parse(jsonText);
+          var topKeys = Object.keys(parsed);
+          console.log('[AmexCapture] parsed JSON top-level keys:', JSON.stringify(topKeys));
+          // Log offer counts
+          var eligibleCount = 0;
+          var enrolledCount = 0;
+          if (parsed.recommendedOffers && parsed.recommendedOffers.offersList) {
+            var pages = Object.keys(parsed.recommendedOffers.offersList);
+            pages.forEach(function(p) { eligibleCount += (parsed.recommendedOffers.offersList[p] || []).length; });
+            console.log('[AmexCapture] recommendedOffers pages:', JSON.stringify(pages), 'total offers:', eligibleCount);
+          } else {
+            console.log('[AmexCapture] recommendedOffers missing or no offersList');
+          }
+          if (parsed.addedToCard && parsed.addedToCard.offersList) {
+            var epages = Object.keys(parsed.addedToCard.offersList);
+            epages.forEach(function(p) { enrolledCount += (parsed.addedToCard.offersList[p] || []).length; });
+            console.log('[AmexCapture] addedToCard pages:', JSON.stringify(epages), 'total offers:', enrolledCount);
+          } else {
+            console.log('[AmexCapture] addedToCard missing or no offersList');
+          }
+          console.log('[AmexCapture] posting CAPTURE_JSON to RN bridge');
           window.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'CAPTURE_JSON',
             json: parsed,
             cardLabel: cardLabel,
           }));
         } catch(e) {
+          console.log('[AmexCapture] JSON parse error:', e.message, 'first 200 chars:', jsonText.substring(0, 200));
           window.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'ERROR',
             message: 'AmexCapture JSON parse error: ' + e.message,
@@ -188,54 +227,81 @@ export const buildAmexJsonCaptureJs = () => `
       }
 
       // ── XHR interceptor ──────────────────────────────
-      var OrigXHR = window.XMLHttpRequest;
-      function PatchedXHR() {
-        var xhr = new OrigXHR();
-        var _url = '';
-        var origOpen = xhr.open.bind(xhr);
-        xhr.open = function(method, url) {
-          _url = url || '';
-          return origOpen.apply(xhr, arguments);
-        };
-        var origSend = xhr.send.bind(xhr);
-        xhr.send = function() {
-          if (_url.includes('ReadOffersHubPresentation') && window.__amexJsonCaptureArmed) {
-            xhr.addEventListener('load', function() {
-              if (xhr.status >= 200 && xhr.status < 300) {
-                console.log('[AmexCapture] XHR intercepted ReadOffersHubPresentation');
-                fireCapture(xhr.responseText);
-              }
-            });
-          }
-          return origSend.apply(xhr, arguments);
-        };
-        return xhr;
+      // Only patch once to avoid stacking interceptors on re-arm
+      if (!window.__amexXhrPatched) {
+        window.__amexXhrPatched = true;
+        var OrigXHR = window.XMLHttpRequest;
+        function PatchedXHR() {
+          var xhr = new OrigXHR();
+          var _url = '';
+          var origOpen = xhr.open.bind(xhr);
+          xhr.open = function(method, url) {
+            _url = url || '';
+            console.log('[AmexCapture:XHR] open url:', _url.substring(0, 120));
+            return origOpen.apply(xhr, arguments);
+          };
+          var origSend = xhr.send.bind(xhr);
+          xhr.send = function() {
+            if (_url.includes('ReadOffersHubPresentation')) {
+              console.log('[AmexCapture:XHR] ReadOffersHubPresentation detected, armed=', window.__amexJsonCaptureArmed);
+              xhr.addEventListener('load', function() {
+                console.log('[AmexCapture:XHR] response status=' + xhr.status + ' responseText.length=' + (xhr.responseText || '').length);
+                if (xhr.status >= 200 && xhr.status < 300 && window.__amexJsonCaptureArmed) {
+                  fireCapture(xhr.responseText, 'XHR');
+                }
+              });
+            }
+            return origSend.apply(xhr, arguments);
+          };
+          return xhr;
+        }
+        PatchedXHR.prototype = OrigXHR.prototype;
+        window.XMLHttpRequest = PatchedXHR;
+        console.log('[AmexCapture] XHR interceptor installed');
+      } else {
+        console.log('[AmexCapture] XHR interceptor already installed, re-armed only');
       }
-      PatchedXHR.prototype = OrigXHR.prototype;
-      window.XMLHttpRequest = PatchedXHR;
 
       // ── fetch interceptor ─────────────────────────────
-      var origFetch = window.fetch;
-      window.fetch = function(input, init) {
-        var url = (typeof input === 'string' ? input : (input && input.url)) || '';
-        var p = origFetch.apply(window, arguments);
-        if (url.includes('ReadOffersHubPresentation') && window.__amexJsonCaptureArmed) {
-          p = p.then(function(response) {
-            var cloned = response.clone();
-            cloned.text().then(function(text) {
-              if (response.ok) {
-                console.log('[AmexCapture] fetch intercepted ReadOffersHubPresentation');
-                fireCapture(text);
-              }
+      if (!window.__amexFetchPatched) {
+        window.__amexFetchPatched = true;
+        var origFetch = window.fetch;
+        window.fetch = function(input, init) {
+          var url = (typeof input === 'string' ? input : (input && input.url)) || '';
+          if (url.includes('ReadOffersHubPresentation')) {
+            console.log('[AmexCapture:fetch] ReadOffersHubPresentation detected, armed=', window.__amexJsonCaptureArmed);
+          } else {
+            // Log all fetch URLs at trace level so we know what APIs Amex calls
+            console.log('[AmexCapture:fetch] url:', url.substring(0, 120));
+          }
+          var p = origFetch.apply(window, arguments);
+          if (url.includes('ReadOffersHubPresentation')) {
+            p = p.then(function(response) {
+              console.log('[AmexCapture:fetch] ReadOffersHubPresentation response ok=' + response.ok + ' status=' + response.status);
+              var cloned = response.clone();
+              cloned.text().then(function(text) {
+                console.log('[AmexCapture:fetch] response body length=' + text.length);
+                if (response.ok && window.__amexJsonCaptureArmed) {
+                  fireCapture(text, 'fetch');
+                } else if (!response.ok) {
+                  console.log('[AmexCapture:fetch] response not ok, skipping capture');
+                } else {
+                  console.log('[AmexCapture:fetch] not armed, skipping capture');
+                }
+              });
+              return response;
             });
-            return response;
-          });
-        }
-        return p;
-      };
+          }
+          return p;
+        };
+        console.log('[AmexCapture] fetch interceptor installed');
+      } else {
+        console.log('[AmexCapture] fetch interceptor already installed, re-armed only');
+      }
 
-      console.log('[AmexCapture] XHR+fetch interceptor armed');
+      console.log('[AmexCapture] interceptor armed and ready');
     } catch(e) {
+      console.log('[AmexCapture] SETUP ERROR:', e.message);
       window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'ERROR', message: 'AmexCapture setup error: ' + e.message }));
     }
   })();
@@ -279,8 +345,10 @@ export const amexHandleLoadEnd = ({
   const onOffersPage = phaseMatch && (onEligible || onEnrolled);
 
   console.log(
-    `[amexHandleLoadEnd] onLogin=${onLogin} onEligible=${onEligible} onEnrolled=${onEnrolled}`,
-    `syncPhase=${syncPhase} detectedPhase=${detectedPhase} phaseMatch=${phaseMatch} cardsDiscovered=${cardsDiscovered}`
+    `[amexHandleLoadEnd] url=${url}`,
+    `| onLogin=${onLogin} onEligible=${onEligible} onEnrolled=${onEnrolled}`,
+    `| syncPhase=${syncPhase} detectedPhase=${detectedPhase} phaseMatch=${phaseMatch}`,
+    `| cardsDiscovered=${cardsDiscovered} onOffersPage=${onOffersPage}`
   );
 
   if (onOffersPage && !cardsDiscovered) {

--- a/mobile/components/sync/amexSync.js
+++ b/mobile/components/sync/amexSync.js
@@ -26,24 +26,15 @@
 //   The interceptor is injected once on page load and posts CAPTURE_JSON
 //   when the next matching response arrives.
 //
-// Fixes applied:
-//   1. Only forward responseType === 'REPLACE' to sync pipeline.
-//      Amex fires UPDATE (partial) first, then REPLACE (full). We want the full one.
-//   2. buildAmexJsonCaptureJs no longer auto-sets __amexJsonCaptureArmed = true.
-//      Arming is now the caller's responsibility (SyncWebView sets captureArmed
-//      before injecting this, and the bridge gate handles it).
-//      This prevents the interceptor re-arming itself on loadEnd after sync is done.
-//   3. buildAmexClearFiltersJs resets all active filters to "All" so that the
-//      count captured matches what the user sees on screen (not a filtered subset).
-//
-// Amex's SPA may auto-navigate to /offers/enrolled during eligible phase.
-// amexHandleLoadEnd gates injection on syncPhase match to ignore this.
+// Key timing note:
+//   Amex fires ReadOffersHubPresentation (REPLACE) BEFORE CARD_SWITCHED comes
+//   back. So window.__amexJsonCaptureArmed must be set BEFORE injecting the
+//   switch JS — not in the CARD_SWITCHED handler.
 // ─────────────────────────────────────────────
 
 const DETECT_CARDS_INNER = `
   (function detectAmexCards() {
     var options = document.querySelectorAll('[role="option"][data-testid*="CARD_PRODUCT"]');
-    console.log('[AmexDetect] CARD_PRODUCT options found:', options.length);
     var cards = [];
     options.forEach(function(opt, i) {
       var nameEl   = opt.querySelector('[data-testid="simple_switcher_display_name"]');
@@ -53,11 +44,9 @@ const DETECT_CARDS_INNER = `
       var last4    = numRaw.replace(/[^\\d]/g, '').slice(-4);
       var selected = opt.getAttribute('aria-selected') === 'true';
       var testId   = opt.getAttribute('data-testid') || '';
-      console.log('[AmexDetect] card[' + i + '] name=' + name + ' last4=' + last4 + ' selected=' + selected + ' testId=' + testId);
       cards.push({ label: name, last4: last4, testId: testId, index: i, selected: selected });
     });
     var selectedCard = cards.find(function(c) { return c.selected; });
-    console.log('[AmexDetect] posting AMEX_CARDS_DETECTED count=' + cards.length + ' selected=' + (selectedCard ? selectedCard.label : 'none'));
     window.ReactNativeWebView.postMessage(JSON.stringify({
       type: 'AMEX_CARDS_DETECTED',
       cards: cards,
@@ -69,26 +58,21 @@ const DETECT_CARDS_INNER = `
 export const AMEX_OPEN_AND_DETECT_JS = `
   (function() {
     try {
-      console.log('[AmexDetect] AMEX_OPEN_AND_DETECT_JS running');
       var combobox = document.querySelector('[data-testid="simple_switcher_combobox"]');
-      console.log('[AmexDetect] combobox found:', !!combobox);
       if (!combobox) {
         window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'AMEX_CARDS_DETECTED', cards: [], selectedLabel: '', error: 'Combobox not found' }));
         return;
       }
       var alreadyOpen = combobox.getAttribute('aria-expanded') === 'true';
-      console.log('[AmexDetect] combobox alreadyOpen:', alreadyOpen);
       if (alreadyOpen) {
         ${DETECT_CARDS_INNER}
         return;
       }
       combobox.click();
-      console.log('[AmexDetect] combobox clicked, waiting 600ms for listbox...');
       setTimeout(function() {
         ${DETECT_CARDS_INNER}
       }, 600);
     } catch(e) {
-      console.log('[AmexDetect] ERROR:', e.message);
       window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'AMEX_CARDS_DETECTED', cards: [], selectedLabel: '', error: e.message }));
     }
   })();
@@ -98,28 +82,20 @@ export const AMEX_OPEN_AND_DETECT_JS = `
 export const buildAmexSwitchCardJs = (testId, timeoutMs = 3500) => `
   (function() {
     try {
-      console.log('[AmexSwitch] buildAmexSwitchCardJs running for testId=${testId} timeout=${timeoutMs}ms');
       var combobox = document.querySelector('[data-testid="simple_switcher_combobox"]');
-      console.log('[AmexSwitch] combobox found:', !!combobox);
       if (!combobox) {
         window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'CARD_SWITCH_ERROR', message: 'Amex combobox not found' }));
         return;
       }
       combobox.click();
-      console.log('[AmexSwitch] combobox clicked, waiting 600ms...');
       setTimeout(function() {
         var option = document.querySelector('[data-testid="${testId}"]');
-        console.log('[AmexSwitch] exact testId match found:', !!option);
-        if (!option) {
-          option = document.querySelector('[role="option"]');
-          console.log('[AmexSwitch] fallback [role=option] found:', !!option);
-        }
+        if (!option) option = document.querySelector('[role="option"]');
         if (!option) {
           window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'CARD_SWITCH_ERROR', message: 'No switchable option found for: ${testId}' }));
           return;
         }
         option.click();
-        console.log('[AmexSwitch] option clicked, waiting ${timeoutMs}ms for re-render...');
         setTimeout(function() {
           var displayEl = document.querySelector('[data-testid="simple_switcher_selected_option_display"]');
           var nameEl    = displayEl ? displayEl.querySelector('[data-testid="simple_switcher_display_name"]') : null;
@@ -128,7 +104,6 @@ export const buildAmexSwitchCardJs = (testId, timeoutMs = 3500) => `
           var numRaw    = numEl  ? numEl.innerText.trim()  : '';
           var last4     = numRaw.replace(/[^\\d]/g, '').slice(-4);
           var cardLabel = name + (last4 ? ' (...' + last4 + ')' : '');
-          console.log('[AmexSwitch] CARD_SWITCHED cardLabel=' + cardLabel + ' expectedTestId=${testId}');
           window.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'CARD_SWITCHED',
             cardLabel: cardLabel,
@@ -137,7 +112,6 @@ export const buildAmexSwitchCardJs = (testId, timeoutMs = 3500) => `
         }, ${timeoutMs});
       }, 600);
     } catch(e) {
-      console.log('[AmexSwitch] ERROR:', e.message);
       window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'CARD_SWITCH_ERROR', message: e.message }));
     }
   })();
@@ -156,58 +130,29 @@ export const AMEX_READ_CARD_LABEL_JS = `
   })()
 `;
 
-// ─────────────────────────────────────────────
-// buildAmexClearFiltersJs
-// Resets all active filter chips to "All" so the next
-// ReadOffersHubPresentation call returns the full unfiltered offer set.
-// This ensures the captured count matches what the user sees on screen.
-// Safe to call even if no filters are active — it's a no-op in that case.
-// ─────────────────────────────────────────────
+// Resets all active filter chips so the full unfiltered offer set is returned.
 export const buildAmexClearFiltersJs = () => `
   (function() {
     try {
-      console.log('[AmexFilters] clearing active filters before capture');
-      // Active filter chips have aria-pressed="true" or aria-selected="true"
-      // Amex uses button chips with data-testid containing "filter"
       var activeFilters = document.querySelectorAll(
         '[data-testid*="filter"][aria-pressed="true"], [data-testid*="filter"][aria-selected="true"]'
       );
-      console.log('[AmexFilters] active filter chips found:', activeFilters.length);
-      activeFilters.forEach(function(chip) {
-        console.log('[AmexFilters] clicking to deactivate:', chip.getAttribute('data-testid'));
-        chip.click();
-      });
-      // Also look for any "All" chip and click it to ensure default state
+      activeFilters.forEach(function(chip) { chip.click(); });
       var allChip = document.querySelector('[data-testid*="filter-all"], [data-testid*="RECOMMENDED"]');
       if (allChip && allChip.getAttribute('aria-pressed') !== 'true') {
-        console.log('[AmexFilters] clicking All/Recommended chip:', allChip.getAttribute('data-testid'));
         allChip.click();
       }
-      console.log('[AmexFilters] filter reset complete');
-    } catch(e) {
-      console.log('[AmexFilters] ERROR clearing filters:', e.message);
-    }
+    } catch(e) { /* silent — filter clear is best-effort */ }
   })();
   true;
 `;
 
-// ─────────────────────────────────────────────
-// buildAmexJsonCaptureJs
-// Intercepts ALL ReadOffersHubPresentation calls.
-// Every response is:
-//   1. Posted as CAPTURE_JSON to RN (only when armed, for actual sync)
-//      but ONLY when responseType === 'REPLACE' (full dataset, not partial UPDATE)
-//   2. ALWAYS dumped to api/debug-dumps/ via DEBUG_DUMP message
-//
-// NOTE: This function no longer auto-sets __amexJsonCaptureArmed = true.
-// The caller (SyncWebView via captureArmed ref) controls arming via
-// window.__amexJsonCaptureArmed. This prevents re-arming after sync completes.
-// ─────────────────────────────────────────────
+// Intercepts ReadOffersHubPresentation XHR/fetch.
+// Only forwards REPLACE responses when window.__amexJsonCaptureArmed = true.
+// Arming is done externally by SyncWebView — this function never auto-arms.
 export const buildAmexJsonCaptureJs = () => `
   (function() {
     try {
-      console.log('[AmexCapture] buildAmexJsonCaptureJs called. currently armed:', !!window.__amexJsonCaptureArmed);
-
       if (!window.__amexCallCounter) window.__amexCallCounter = 0;
 
       function readCardLabel() {
@@ -217,55 +162,25 @@ export const buildAmexJsonCaptureJs = () => `
         var name      = nameEl ? nameEl.innerText.trim() : '';
         var numRaw    = numEl  ? numEl.innerText.trim()  : '';
         var last4     = numRaw.replace(/[^\\d]/g, '').slice(-4);
-        var label     = name + (last4 ? ' (...' + last4 + ')' : '');
-        console.log('[AmexCapture] readCardLabel =', label || '(empty)');
-        return label;
+        return name + (last4 ? ' (...' + last4 + ')' : '');
       }
 
       function fireCapture(jsonText, source) {
-        var seq = ++window.__amexCallCounter;
-        var cardLabel = readCardLabel();
-        console.log('[AmexCapture] fireCapture #' + seq + ' source=' + source + ' jsonText.length=' + jsonText.length + ' cardLabel=' + cardLabel + ' armed=' + window.__amexJsonCaptureArmed);
-
+        ++window.__amexCallCounter;
         try {
           var parsed = JSON.parse(jsonText);
           var responseType = parsed && parsed.responseType;
-          console.log('[AmexCapture] #' + seq + ' parsed JSON top-level keys:', JSON.stringify(Object.keys(parsed)), 'responseType:', responseType);
-
-          // ── DEBUG: always dump every call regardless of armed/responseType ──
-          var safeLabel = (cardLabel || 'unknown').replace(/[^a-z0-9]/gi, '_');
-          window.ReactNativeWebView.postMessage(JSON.stringify({
-            type: 'DEBUG_DUMP',
-            label: 'ReadOffersHubPresentation_' + safeLabel + '_call' + seq,
-            data: parsed,
-          }));
-          // ────────────────────────────────────────────────────────────────────
-
-          // Fix 1: Only process full REPLACE responses, skip partial UPDATEs.
-          // Amex fires UPDATE first (partial/intermediate), then REPLACE (full).
-          // Capturing UPDATE gives fewer offers than what the user sees on screen.
-          if (responseType !== 'REPLACE') {
-            console.log('[AmexCapture] #' + seq + ' skipping — responseType is', responseType, '(only REPLACE is captured)');
-            return;
-          }
-
-          // Fix 2: Only forward to sync pipeline when armed.
-          // Caller sets window.__amexJsonCaptureArmed = true before injecting this
-          // script (via SyncWebView captureArmed ref). We do NOT auto-set it here
-          // to prevent re-arming after sync is complete.
+          // Only process full REPLACE responses — skip partial UPDATEs.
+          if (responseType !== 'REPLACE') return;
           if (window.__amexJsonCaptureArmed) {
             window.__amexJsonCaptureArmed = false;
-            console.log('[AmexCapture] #' + seq + ' posting CAPTURE_JSON to RN bridge');
             window.ReactNativeWebView.postMessage(JSON.stringify({
               type: 'CAPTURE_JSON',
               json: parsed,
-              cardLabel: cardLabel,
+              cardLabel: readCardLabel(),
             }));
-          } else {
-            console.log('[AmexCapture] #' + seq + ' REPLACE received but not armed — ignoring');
           }
         } catch(e) {
-          console.log('[AmexCapture] #' + seq + ' JSON parse error:', e.message);
           window.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'ERROR',
             message: 'AmexCapture JSON parse error: ' + e.message,
@@ -282,18 +197,13 @@ export const buildAmexJsonCaptureJs = () => `
           var origOpen = xhr.open.bind(xhr);
           xhr.open = function(method, url) {
             _url = url || '';
-            console.log('[AmexCapture:XHR] open url:', _url.substring(0, 120));
             return origOpen.apply(xhr, arguments);
           };
           var origSend = xhr.send.bind(xhr);
           xhr.send = function() {
             if (_url.includes('ReadOffersHubPresentation')) {
-              console.log('[AmexCapture:XHR] ReadOffersHubPresentation detected, armed=', window.__amexJsonCaptureArmed);
               xhr.addEventListener('load', function() {
-                console.log('[AmexCapture:XHR] response status=' + xhr.status + ' responseText.length=' + (xhr.responseText || '').length);
-                if (xhr.status >= 200 && xhr.status < 300) {
-                  fireCapture(xhr.responseText, 'XHR');
-                }
+                if (xhr.status >= 200 && xhr.status < 300) fireCapture(xhr.responseText, 'XHR');
               });
             }
             return origSend.apply(xhr, arguments);
@@ -302,9 +212,6 @@ export const buildAmexJsonCaptureJs = () => `
         }
         PatchedXHR.prototype = OrigXHR.prototype;
         window.XMLHttpRequest = PatchedXHR;
-        console.log('[AmexCapture] XHR interceptor installed');
-      } else {
-        console.log('[AmexCapture] XHR interceptor already installed, re-armed only');
       }
 
       if (!window.__amexFetchPatched) {
@@ -312,37 +219,20 @@ export const buildAmexJsonCaptureJs = () => `
         var origFetch = window.fetch;
         window.fetch = function(input, init) {
           var url = (typeof input === 'string' ? input : (input && input.url)) || '';
-          if (url.includes('ReadOffersHubPresentation')) {
-            console.log('[AmexCapture:fetch] ReadOffersHubPresentation detected, armed=', window.__amexJsonCaptureArmed);
-          } else {
-            console.log('[AmexCapture:fetch] url:', url.substring(0, 120));
-          }
           var p = origFetch.apply(window, arguments);
           if (url.includes('ReadOffersHubPresentation')) {
             p = p.then(function(response) {
-              console.log('[AmexCapture:fetch] response ok=' + response.ok + ' status=' + response.status);
               var cloned = response.clone();
               cloned.text().then(function(text) {
-                console.log('[AmexCapture:fetch] response body length=' + text.length);
-                if (response.ok) {
-                  fireCapture(text, 'fetch');
-                } else {
-                  console.log('[AmexCapture:fetch] response not ok, skipping capture');
-                }
+                if (response.ok) fireCapture(text, 'fetch');
               });
               return response;
             });
           }
           return p;
         };
-        console.log('[AmexCapture] fetch interceptor installed');
-      } else {
-        console.log('[AmexCapture] fetch interceptor already installed, re-armed only');
       }
-
-      console.log('[AmexCapture] interceptor ready — armed:', !!window.__amexJsonCaptureArmed);
     } catch(e) {
-      console.log('[AmexCapture] SETUP ERROR:', e.message);
       window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'ERROR', message: 'AmexCapture setup error: ' + e.message }));
     }
   })();
@@ -369,15 +259,7 @@ export const amexHandleLoadEnd = ({
   const phaseMatch   = detectedPhase === syncPhase;
   const onOffersPage = phaseMatch && (onEligible || onEnrolled);
 
-  console.log(
-    `[amexHandleLoadEnd] url=${url}`,
-    `| onLogin=${onLogin} onEligible=${onEligible} onEnrolled=${onEnrolled}`,
-    `| syncPhase=${syncPhase} detectedPhase=${detectedPhase} phaseMatch=${phaseMatch}`,
-    `| cardsDiscovered=${cardsDiscovered} onOffersPage=${onOffersPage}`
-  );
-
   if (onOffersPage && !cardsDiscovered) {
-    console.log('[amexHandleLoadEnd] injecting AMEX_OPEN_AND_DETECT_JS');
     injectJavaScript(AMEX_OPEN_AND_DETECT_JS);
   }
 

--- a/mobile/components/sync/amexSync.js
+++ b/mobile/components/sync/amexSync.js
@@ -26,6 +26,16 @@
 //   The interceptor is injected once on page load and posts CAPTURE_JSON
 //   when the next matching response arrives.
 //
+// Fixes applied:
+//   1. Only forward responseType === 'REPLACE' to sync pipeline.
+//      Amex fires UPDATE (partial) first, then REPLACE (full). We want the full one.
+//   2. buildAmexJsonCaptureJs no longer auto-sets __amexJsonCaptureArmed = true.
+//      Arming is now the caller's responsibility (SyncWebView sets captureArmed
+//      before injecting this, and the bridge gate handles it).
+//      This prevents the interceptor re-arming itself on loadEnd after sync is done.
+//   3. buildAmexClearFiltersJs resets all active filters to "All" so that the
+//      count captured matches what the user sees on screen (not a filtered subset).
+//
 // Amex's SPA may auto-navigate to /offers/enrolled during eligible phase.
 // amexHandleLoadEnd gates injection on syncPhase match to ignore this.
 // ─────────────────────────────────────────────
@@ -147,19 +157,56 @@ export const AMEX_READ_CARD_LABEL_JS = `
 `;
 
 // ─────────────────────────────────────────────
+// buildAmexClearFiltersJs
+// Resets all active filter chips to "All" so the next
+// ReadOffersHubPresentation call returns the full unfiltered offer set.
+// This ensures the captured count matches what the user sees on screen.
+// Safe to call even if no filters are active — it's a no-op in that case.
+// ─────────────────────────────────────────────
+export const buildAmexClearFiltersJs = () => `
+  (function() {
+    try {
+      console.log('[AmexFilters] clearing active filters before capture');
+      // Active filter chips have aria-pressed="true" or aria-selected="true"
+      // Amex uses button chips with data-testid containing "filter"
+      var activeFilters = document.querySelectorAll(
+        '[data-testid*="filter"][aria-pressed="true"], [data-testid*="filter"][aria-selected="true"]'
+      );
+      console.log('[AmexFilters] active filter chips found:', activeFilters.length);
+      activeFilters.forEach(function(chip) {
+        console.log('[AmexFilters] clicking to deactivate:', chip.getAttribute('data-testid'));
+        chip.click();
+      });
+      // Also look for any "All" chip and click it to ensure default state
+      var allChip = document.querySelector('[data-testid*="filter-all"], [data-testid*="RECOMMENDED"]');
+      if (allChip && allChip.getAttribute('aria-pressed') !== 'true') {
+        console.log('[AmexFilters] clicking All/Recommended chip:', allChip.getAttribute('data-testid'));
+        allChip.click();
+      }
+      console.log('[AmexFilters] filter reset complete');
+    } catch(e) {
+      console.log('[AmexFilters] ERROR clearing filters:', e.message);
+    }
+  })();
+  true;
+`;
+
+// ─────────────────────────────────────────────
 // buildAmexJsonCaptureJs
 // Intercepts ALL ReadOffersHubPresentation calls.
 // Every response is:
 //   1. Posted as CAPTURE_JSON to RN (only when armed, for actual sync)
+//      but ONLY when responseType === 'REPLACE' (full dataset, not partial UPDATE)
 //   2. ALWAYS dumped to api/debug-dumps/ via DEBUG_DUMP message
-//      so we can see every call Amex makes and its full response.
+//
+// NOTE: This function no longer auto-sets __amexJsonCaptureArmed = true.
+// The caller (SyncWebView via captureArmed ref) controls arming via
+// window.__amexJsonCaptureArmed. This prevents re-arming after sync completes.
 // ─────────────────────────────────────────────
 export const buildAmexJsonCaptureJs = () => `
   (function() {
     try {
       console.log('[AmexCapture] buildAmexJsonCaptureJs called. currently armed:', !!window.__amexJsonCaptureArmed);
-
-      window.__amexJsonCaptureArmed = true;
 
       if (!window.__amexCallCounter) window.__amexCallCounter = 0;
 
@@ -182,18 +229,30 @@ export const buildAmexJsonCaptureJs = () => `
 
         try {
           var parsed = JSON.parse(jsonText);
-          console.log('[AmexCapture] #' + seq + ' parsed JSON top-level keys:', JSON.stringify(Object.keys(parsed)));
+          var responseType = parsed && parsed.responseType;
+          console.log('[AmexCapture] #' + seq + ' parsed JSON top-level keys:', JSON.stringify(Object.keys(parsed)), 'responseType:', responseType);
 
-          // ── DEBUG: always dump every call regardless of armed state ──
+          // ── DEBUG: always dump every call regardless of armed/responseType ──
           var safeLabel = (cardLabel || 'unknown').replace(/[^a-z0-9]/gi, '_');
           window.ReactNativeWebView.postMessage(JSON.stringify({
             type: 'DEBUG_DUMP',
             label: 'ReadOffersHubPresentation_' + safeLabel + '_call' + seq,
             data: parsed,
           }));
-          // ────────────────────────────────────────────────────────────
+          // ────────────────────────────────────────────────────────────────────
 
-          // Only forward to sync pipeline when armed
+          // Fix 1: Only process full REPLACE responses, skip partial UPDATEs.
+          // Amex fires UPDATE first (partial/intermediate), then REPLACE (full).
+          // Capturing UPDATE gives fewer offers than what the user sees on screen.
+          if (responseType !== 'REPLACE') {
+            console.log('[AmexCapture] #' + seq + ' skipping — responseType is', responseType, '(only REPLACE is captured)');
+            return;
+          }
+
+          // Fix 2: Only forward to sync pipeline when armed.
+          // Caller sets window.__amexJsonCaptureArmed = true before injecting this
+          // script (via SyncWebView captureArmed ref). We do NOT auto-set it here
+          // to prevent re-arming after sync is complete.
           if (window.__amexJsonCaptureArmed) {
             window.__amexJsonCaptureArmed = false;
             console.log('[AmexCapture] #' + seq + ' posting CAPTURE_JSON to RN bridge');
@@ -202,6 +261,8 @@ export const buildAmexJsonCaptureJs = () => `
               json: parsed,
               cardLabel: cardLabel,
             }));
+          } else {
+            console.log('[AmexCapture] #' + seq + ' REPLACE received but not armed — ignoring');
           }
         } catch(e) {
           console.log('[AmexCapture] #' + seq + ' JSON parse error:', e.message);
@@ -279,7 +340,7 @@ export const buildAmexJsonCaptureJs = () => `
         console.log('[AmexCapture] fetch interceptor already installed, re-armed only');
       }
 
-      console.log('[AmexCapture] interceptor armed and ready');
+      console.log('[AmexCapture] interceptor ready — armed:', !!window.__amexJsonCaptureArmed);
     } catch(e) {
       console.log('[AmexCapture] SETUP ERROR:', e.message);
       window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'ERROR', message: 'AmexCapture setup error: ' + e.message }));

--- a/mobile/components/sync/amexSync.js
+++ b/mobile/components/sync/amexSync.js
@@ -178,31 +178,16 @@ export const buildAmexJsonCaptureJs = () => `
         console.log('[AmexCapture] fireCapture source=' + source + ' jsonText.length=' + jsonText.length + ' cardLabel=' + cardLabel);
         try {
           var parsed = JSON.parse(jsonText);
-          var topKeys = Object.keys(parsed);
-          console.log('[AmexCapture] parsed JSON top-level keys:', JSON.stringify(topKeys));
+          console.log('[AmexCapture] parsed JSON top-level keys:', JSON.stringify(Object.keys(parsed)));
 
           if (parsed.recommendedOffers && parsed.recommendedOffers.offersList) {
-            var pages = Object.keys(parsed.recommendedOffers.offersList);
-            var titles = [];
-            pages.forEach(function(p) {
-              var pageOffers = parsed.recommendedOffers.offersList[p] || [];
-              pageOffers.forEach(function(o) { titles.push(o.title || '(no title)'); });
-            });
-            console.log('[AmexCapture] recommendedOffers pages:', JSON.stringify(pages), 'total:', titles.length);
-            console.log('[AmexCapture] recommendedOffers titles:', JSON.stringify(titles));
+            console.log('[AmexCapture] recommendedOffers.offersList:', JSON.stringify(parsed.recommendedOffers.offersList));
           } else {
             console.log('[AmexCapture] recommendedOffers missing or no offersList');
           }
 
           if (parsed.addedToCard && parsed.addedToCard.offersList) {
-            var epages = Object.keys(parsed.addedToCard.offersList);
-            var etitles = [];
-            epages.forEach(function(p) {
-              var pageOffers = parsed.addedToCard.offersList[p] || [];
-              pageOffers.forEach(function(o) { etitles.push(o.title || '(no title)'); });
-            });
-            console.log('[AmexCapture] addedToCard pages:', JSON.stringify(epages), 'total:', etitles.length);
-            console.log('[AmexCapture] addedToCard titles:', JSON.stringify(etitles));
+            console.log('[AmexCapture] addedToCard.offersList:', JSON.stringify(parsed.addedToCard.offersList));
           } else {
             console.log('[AmexCapture] addedToCard missing or no offersList');
           }

--- a/mobile/components/sync/amexSync.js
+++ b/mobile/components/sync/amexSync.js
@@ -1,5 +1,6 @@
 // ─────────────────────────────────────────────
-// AMEX SYNC — JS injection strings
+// AMEX SYNC — JS injection strings + load handler
+//
 // Amex uses a combobox + listbox pattern:
 //   [data-testid="simple_switcher_combobox"]
 //   [role="option"][data-testid*="CARD_PRODUCT"]
@@ -10,6 +11,13 @@
 //   3. Wait for re-render, then confirm via display label
 //
 // CARD_PRODUCT filter excludes checking/savings accounts.
+//
+// Two-phase sync:
+//   Phase 1 (eligible)  → global.americanexpress.com/offers/eligible
+//   Phase 2 (enrolled)  → global.americanexpress.com/offers/enrolled
+//
+// All Amex-specific URL detection logic lives in amexHandleLoadEnd()
+// so SyncWebView stays bank-agnostic.
 // ─────────────────────────────────────────────
 
 const DETECT_CARDS_INNER = `
@@ -109,3 +117,45 @@ export const AMEX_READ_CARD_LABEL_JS = `
     return name + (last4 ? ' (...' + last4 + ')' : '');
   })()
 `;
+
+// ─────────────────────────────────────────────
+// amexHandleLoadEnd
+// Call this from SyncWebView.handleLoadEnd when bank === 'amex'.
+// Returns { onOffersPage, phase } so SyncWebView can update state.
+// Also triggers card detection injection when appropriate.
+//
+// phases: 'eligible' | 'enrolled'
+// ─────────────────────────────────────────────
+export const amexHandleLoadEnd = ({
+  url,
+  config,
+  syncPhase,          // current phase ref value
+  cardsDiscovered,    // ref.current
+  injectJavaScript,   // webViewRef.current?.injectJavaScript
+}) => {
+  const lower = url.toLowerCase();
+  const onLogin = (config.loginPaths || []).some(p => lower.includes(p.toLowerCase()));
+
+  const onEligible = !onLogin && lower.includes(config.eligiblePath.toLowerCase());
+  const onEnrolled = !onLogin && lower.includes(config.enrolledPath.toLowerCase());
+  const onOffersPage = onEligible || onEnrolled;
+
+  // Determine phase from URL — URL is source of truth
+  const detectedPhase = onEnrolled ? 'enrolled' : 'eligible';
+
+  console.log(
+    `[amexHandleLoadEnd] onLogin=${onLogin} onEligible=${onEligible} onEnrolled=${onEnrolled}`,
+    `syncPhase=${syncPhase} detectedPhase=${detectedPhase} cardsDiscovered=${cardsDiscovered}`
+  );
+
+  // Inject card detection when:
+  // - we are on an offers page
+  // - cards not yet discovered for this phase
+  //   (cardsDiscovered resets to false when phase transitions)
+  if (onOffersPage && !cardsDiscovered) {
+    console.log('[amexHandleLoadEnd] injecting AMEX_OPEN_AND_DETECT_JS');
+    injectJavaScript(AMEX_OPEN_AND_DETECT_JS);
+  }
+
+  return { onOffersPage, detectedPhase };
+};

--- a/mobile/components/sync/bankConfig.js
+++ b/mobile/components/sync/bankConfig.js
@@ -29,18 +29,20 @@ export const BANK_CONFIG = {
   amex: {
     // Entry URL — redirects to login if not authenticated
     url: 'https://www.americanexpress.com/en-us/benefits/offers/',
-    // After login Amex lands on global.americanexpress.com
-    offersUrl: 'https://global.americanexpress.com/offers/eligible',
+    // After login Amex lands on global.americanexpress.com/offers (with query params)
+    // We navigate here to ensure we're on the eligible offers tab
+    offersUrl: 'https://global.americanexpress.com/offers',
     // Activated/enrolled offers page
     enrolledUrl: 'https://global.americanexpress.com/offers/enrolled',
     label: 'Amex Offers',
     color: '#007ac1',
-    // IMPORTANT: must only match global.americanexpress.com/offers* NOT
-    // americanexpress.com/en-us/benefits/offers (marketing page)
-    eligiblePath: 'global.americanexpress.com/offers/eligible',
+    // eligiblePath: matches global.americanexpress.com/offers (with or without query params)
+    // MUST NOT match enrolledPath — check enrolled first in amexHandleLoadEnd
+    // MUST NOT match americanexpress.com/en-us/benefits/offers (marketing page)
+    eligiblePath: 'global.americanexpress.com/offers',
     enrolledPath: 'global.americanexpress.com/offers/enrolled',
     offersPaths: ['global.americanexpress.com/offers'],
-    loginPaths: ['/account/login', '/login', '/sign-in', '/identity', '/auth', '/challenge'],
+    loginPaths: ['/account/login', '/login', '/sign-in', '/identity', '/auth', '/challenge', 'two-step-verification'],
     // Real offer rows are direct DIV children of this container
     gridSelector: '[data-testid="listViewContainer"]',
     captureMaxBytes: 500000,

--- a/mobile/components/sync/bankConfig.js
+++ b/mobile/components/sync/bankConfig.js
@@ -31,10 +31,14 @@ export const BANK_CONFIG = {
     url: 'https://www.americanexpress.com/en-us/benefits/offers/',
     // After login Amex lands on global.americanexpress.com
     offersUrl: 'https://global.americanexpress.com/offers/eligible',
+    // Activated/enrolled offers page
+    enrolledUrl: 'https://global.americanexpress.com/offers/enrolled',
     label: 'Amex Offers',
     color: '#007ac1',
     // IMPORTANT: must only match global.americanexpress.com/offers* NOT
     // americanexpress.com/en-us/benefits/offers (marketing page)
+    eligiblePath: 'global.americanexpress.com/offers/eligible',
+    enrolledPath: 'global.americanexpress.com/offers/enrolled',
     offersPaths: ['global.americanexpress.com/offers'],
     loginPaths: ['/account/login', '/login', '/sign-in', '/identity', '/auth', '/challenge'],
     // Real offer rows are direct DIV children of this container


### PR DESCRIPTION
## Overview
This PR delivers the full Amex two-phase offer sync: **eligible** (unenrolled) offers + **activated/enrolled** offers, synced automatically per card in a single user-initiated sync. It also replaces the brittle HTML-scraping approach with a clean **XHR/fetch JSON interception** strategy and fixes several data integrity issues in the API.

---

## 1. Core Feature — Two-Phase Amex Sync

### `mobile/components/sync/amexSync.js`
- Added `buildAmexCardDetectorJs()` — injects JS into WebView to detect the card combobox (`[data-testid^=simple_switcher_product_option_CARD_PRODUCT_]`), extract all card `testId`s and labels, and post `AMEX_CARDS_DETECTED` back to RN
- Added `buildAmexJsonCaptureJs()` — intercepts **XHR and fetch** for `ReadOffersHubPresentation` API calls, armed via `window.__amexJsonCaptureArmed`, only captures `REPLACE` responses (not partial updates), posts `CAPTURE_JSON` message back to RN with full JSON payload
- Added `buildAmexCardSwitchJs(testId)` — clicks the card combobox option by `testId`, clears any active filters before switching so full offer list loads (not a filtered subset)
- Capture arm is set **immediately before** the card switch JS fires so the `REPLACE` response arrives after the arm (prevents race where JSON arrives before RN is ready)
- `buildAmexComboboxCheckJs()` — detects if combobox is present (used to gate card detection)

### `mobile/components/SyncWebView.js`
- Added `syncPhaseRef` + `syncPhaseUi` state (`eligible` | `enrolled`) — tracks current phase in both refs (sync) and state (UI)
- Added `amexCardsRef` — stores detected cards array; `amexCardIndexRef` — pointer to current card being processed; `amexVisitedRef` — count of cards synced this phase
- Added `captureArmedRef` — prevents stale CAPTURE_JSON messages from firing outside of intended capture windows
- `handleLoadEnd()` now calls `amexHandleLoadEnd()` for Amex, keeping the orchestrator bank-agnostic
- `transitionToEnrolled()` — called automatically after last eligible card is processed; navigates to `/offers/enrolled`, resets card index and visited counters without clearing the card list
- `switchToNextAmexCard()` — arms capture, fires card switch JS, increments index; after last card in enrolled phase calls `handleSyncComplete()`
- `handleCaptureResult()` — receives `CAPTURE_JSON` from WebView, POSTs `{ json, bank, cardName, phase }` to `/api/offers/parse`, advances to next card on response
- Status text: `Syncing eligible offers...` → `⏳ Switching to activated offers...` → `Syncing activated offers...` → done
- **Cookies preserved** (removed incognito mode) — Amex uses device trust; incognito caused repeated login redirects
- `pageLoaded` and `onOffersPage` for Amex are driven only by `loadEnd`, not `navState` (Amex fires navState multiple times mid-navigation; using it as source of truth caused premature state resets)
- Eligible and enrolled URL paths are mutually exclusive in detection logic — enrolled navigations during eligible phase are ignored and vice versa

### `mobile/components/sync/bankConfig.js`
- Added `enrolledUrl: 'https://global.americanexpress.com/offers/enrolled'` and `enrolledPath: '/offers/enrolled'` to Amex config
- `eligiblePath` updated to match `/offers` with optional query params (real Amex URL is `/offers` not `/offers/eligible`)
- `offersUrl` is `https://global.americanexpress.com/offers` — deep link that bypasses the `americanexpress.com/en-us/benefits/offers/` landing page redirect

---

## 2. Amex Parser — HTML → JSON

### `api/lib/parsers/amex.js` (full rewrite)
- **Replaced** Cheerio HTML parser with a clean JSON parser reading from the intercepted `ReadOffersHubPresentation` API response
- Reads from `recommendedOffers.offersList` (eligible) or `addedToCard.offersList` (enrolled) depending on `phase` param
- Filters out non-`MERCHANT` offer types (e.g. bank promos, travel credits) — only merchant cashback offers are stored
- Maps each offer: `merchantName` (from `merchantLocalName` or `title`), `cashbackAmount` (regex parsed from `offerDescription`), `cashbackType` (`percent` or `fixed`), `minimumSpend` (comma-stripped), `expiryDate` (ISO string), `isActivated` (forced `true` for enrolled phase, `false` for eligible), `offerDeepLink`
- Handles `+` prefix in points strings (e.g. `Earn +5 Membership Rewards`)
- Handles both `$X` fixed and `X%` percent cashback formats in description regex

---

## 3. API — `POST /api/offers/parse`

### `api/routes/offers.js`
- Route now accepts two shapes:
  - **Amex**: `{ json: object, bank: 'amex', cardName, phase: 'eligible'|'enrolled' }`
  - **Chase**: `{ html: string, bank: 'chase', cardName, phase? }` — **completely unchanged**
- `phase` is passed through to `writeOffersToDB` and stored on every Firestore offer doc
- `isActivated` is overridden based on phase: enrolled → `true`, eligible → `false` (parser value is used as default but API enforces correctness)
- Old purge logic removed — Amex page is the source of truth; we upsert every sync, never delete

### `api/lib/shared/offerUtils.js` — `generateOfferId`
- Added `phase` as 5th parameter, appended to the base64 hash input
- **Why**: eligible and enrolled offers for the same merchant + same expiry + same card would produce identical `offerId`s under the old scheme, causing enrolled offers to silently overwrite eligible ones and the `new` vs `updated` count to be wrong
- `writeOffersToDB` Firestore query now filters by `bank + cardName + phase` so `existingIds` is scoped correctly and new/updated counts are accurate
- `offerId` truncation removed in a prior fix — full base64 string prevents any hash collisions between offers with same merchant across different cards

---

## 4. Bug Fixes (in order)

| Commit | Fix |
|---|---|
| `bc633de` | `eligiblePath` corrected to match `/offers` with query params |
| `930c8e3` | Removed incognito mode — cookies must persist for Amex device trust |
| `2debf3e` | Eligible/enrolled URL detection made mutually exclusive to prevent cross-phase interference |
| `e403efa` | `pageLoaded` no longer reset on `navState` for Amex — `loadEnd` is source of truth |
| `af17465` | Card switcher falls back to first `[role=option]` when `testId` not found (enrolled page uses numeric testIds) |
| `648afdf` | `phase` sent in POST body; `isActivated` derived from phase in API |
| `dc8803b` | `pendingCardLabelRef` introduced — avoids reading stale DOM card label after switch |
| `f0e7173` | Sync button gated on `AMEX_CARDS_DETECTED` — prevents zero-card sync if user taps before detection |
| `7f6f0c8` | `offerId` truncation removed — prevents hash collisions |
| `02f114e` | Purge logic removed — sync is additive only |
| `718520` | Non-MERCHANT offer types filtered; enrolled key corrected in parser |
| `6935c76` | Only `REPLACE` XHR responses captured; filters cleared before each card switch |
| `1dc154f` | Filters explicitly cleared before card switch to ensure full offer list loads |
| `f2cd029` | `captureArmed` set immediately before switch JS fires — prevents race condition |

---

## 5. Cleanup
- All `console.log` removed from `SyncWebView.js`, `amexSync.js`, and `api/routes/offers.js`
- Temporary `DEBUG_DUMP` handler and `/api/debug/dump` endpoint fully removed
- Merchant name comparison log removed after confirming eligible/enrolled offer sets are 100% distinct (zero overlapping merchants)

---

## Testing Checklist
- [ ] Single Amex card: eligible phase syncs → enrolled phase syncs → WebView closes
- [ ] Multi-card (2+ cards): all eligible cards cycle first, then all enrolled cards cycle
- [ ] Sync count is correct — check Firestore offer count matches what API returns
- [ ] `phase` field is present and correct (`eligible` / `enrolled`) on all synced Firestore docs
- [ ] `isActivated` is `true` for enrolled offers, `false` for eligible
- [ ] Re-sync: second sync shows `0 new, N updated` (idempotent)
- [ ] Chase sync: completely unaffected — verify Chase offers still sync correctly
- [ ] Sync button stays disabled until `AMEX_CARDS_DETECTED` fires
- [ ] Status text transitions: `Syncing eligible offers...` → `Switching to activated offers...` → `Syncing activated offers...` → done